### PR TITLE
Remove WfsRails initializer

### DIFF
--- a/config/initializers/wfs_rails.rb
+++ b/config/initializers/wfs_rails.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-# Change the name from the default 'wfs_rails_workflows' to what already
-# exists in the legacy Oracle database
-WfsRails::Workflow.table_name = 'workflow'


### PR DESCRIPTION
We decided that we were unable to use the legacy DB with this code,
so there's no need to set the table name to the legacy table's name.