### PR TITLE
When active-only is passed, show only the current version milestones 

### DIFF
--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -6,9 +6,9 @@ class WorkflowsController < ApplicationController
   def lifecycle
     @objects = WorkflowStep.where(
       repository: params[:repo],
-      druid: params[:druid],
-      version: current_version
+      druid: params[:druid]
     ).where.not(lifecycle: nil)
+    @objects = @objects.where(version: current_version) if params['active-only']
   end
 
   def index


### PR DESCRIPTION
Blocked by #68 
Fixes #69 