### PR TITLE
Set the environment on the prod stage to production

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -3,3 +3,4 @@
 server 'workflow-service-prod.stanford.edu', user: 'workflow', roles: %w[web app db]
 
 Capistrano::OneTimeKey.generate_one_time_key!
+set :rails_env, 'production'

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -3,5 +3,4 @@
 server 'workflow-service-stage.stanford.edu', user: 'workflow', roles: %w[web app db]
 
 Capistrano::OneTimeKey.generate_one_time_key!
-
 set :rails_env, 'production'


### PR DESCRIPTION
Avoid an error when deploying:
```
00:21 deploy:migrating
      01 bundle exec rake db:migrate
      01 config.eager_load is set to nil. Please update your config/environments/*.rb files accordingly:
      01
      01   * development - set it to false
      01   * test - set it to false (unless you use a tool that preloads your test environment)
      01   * production - set it to true
      01
      01 rake aborted!
      01 ActiveRecord::AdapterNotSpecified: 'prod' database is not configured. Available: ["production"]
```