### PR TITLE
Encode query string params in custom parser

### DIFF
--- a/app/controllers/workflow_queues_controller.rb
+++ b/app/controllers/workflow_queues_controller.rb
@@ -63,7 +63,7 @@ class WorkflowQueuesController < ApplicationController
 
   # Because `completed` can have more than one value, we can't use the rails params parser.
   def completed_steps
-    request.query_string.split('&').grep(/^completed=/).map { |v| v.split('=').last }
+    request.query_string.split('&').grep(/^completed=/).map { |v| v.split('=').last }.map { |v| CGI.unescape(v) }
   end
 
   def completed_step_scopes

--- a/spec/requests/objects_for_step_spec.rb
+++ b/spec/requests/objects_for_step_spec.rb
@@ -74,9 +74,9 @@ RSpec.describe 'Objects for workstep', type: :request do
     end
 
     it 'shows the items that are waiting and have met the prereqs' do
-      get '/workflow_queue?waiting=dor:accessionWF:reset-workspace&' \
-          'completed=dor:accessionWF:sdr-ingest-received&' \
-          'completed=dor:accessionWF:provenance-metadata&limit=100&lane-id=default'
+      get '/workflow_queue?waiting=dor%3AaccessionWF%3Areset-workspace&' \
+          'completed=dor%3AaccessionWF%3Asdr-ingest-received&' \
+          'completed=dor%3AaccessionWF%3Aprovenance-metadata&limit=100&lane-id=default'
       expect(response).to render_template(:show)
 
       expect(response.body).to be_equivalent_to <<~XML
@@ -133,7 +133,7 @@ RSpec.describe 'Objects for workstep', type: :request do
     end
 
     it 'shows the items that are waiting' do
-      get '/workflow_queue?waiting=dor:versioningWF:start-accession'
+      get '/workflow_queue?waiting=dor%3AversioningWF%3Astart-accession'
       expect(response).to render_template(:show)
 
       expect(response.body).to be_equivalent_to <<~XML


### PR DESCRIPTION
Else later on we try to split a string like `dor%3AfooWF%3Astep` on `:` and it returns the entire string, not just the step, which causes the completed steps to return a scope with the wrong information.

We did not catch this beforehand because the request spec assumes the query string is decoded when in fact it is encoded.