### PR TITLE
When calling update, but the step doesn't exist, create it.

### DIFF
--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -37,7 +37,7 @@ class WorkflowsController < ApplicationController
   # Update a single WorkflowStep
   def update
     parser = ProcessParser.new(process_from_request_body)
-    step = find_step_for_process
+    step = find_or_create_step_for_process
 
     return render plain: process_mismatch_error(parser), status: :bad_request if parser.process != params[:process]
 
@@ -84,8 +84,11 @@ class WorkflowsController < ApplicationController
     "Status in params (#{params['current-status']}) does not match current status (#{step.status})"
   end
 
-  def find_step_for_process
-    WorkflowStep.find_by!(
+  # Only Hydrus calls this when the objects don't exist.
+  # I suspect we could make Hydrus behave more "as expected", but for now it's
+  # easier to just mirror the behavior of the old Java workflow service - Justin C., Jan 2019
+  def find_or_create_step_for_process
+    WorkflowStep.find_or_create_by(
       repository: params[:repo],
       druid: params[:druid],
       workflow: params[:workflow],

--- a/spec/controllers/workflows_controller_spec.rb
+++ b/spec/controllers/workflows_controller_spec.rb
@@ -49,6 +49,20 @@ RSpec.describe WorkflowsController do
       end
     end
 
+    context 'when no matching step exists (Hydrus does this)' do
+      let(:druid) { 'druid:zz696qh8598' }
+      let(:wf) { WorkflowStep.where(druid: druid, workflow: 'hydrusAssemblyWF', process: 'submit') }
+
+      it 'creates the step' do
+        put :update, body: '<process name="submit" status="completed" elapsed="3" lifecycle="submitted" laneId="default" note="Yay"/>',
+                     params: { repo: 'dor', druid: druid, workflow: 'hydrusAssemblyWF', process: 'submit' }
+
+        expect(wf.pluck(:status)).to eq ['completed']
+        expect(response).to be_no_content
+        expect(SendUpdateMessage).to have_received(:publish).with(druid: druid)
+      end
+    end
+
     context 'with error XML' do
       let(:process_xml) { update_process_to_error }
 


### PR DESCRIPTION
This is a special case for Hydrus.  See https://github.com/sul-dlss/hydrus/pull/260