### PR TITLE
When updating a workflow step, overwrite all of the attributes

### DIFF
--- a/app/services/process_parser.rb
+++ b/app/services/process_parser.rb
@@ -23,14 +23,9 @@ class ProcessParser
   end
 
   def to_h
-    hash = {}
-    PROCESS_ATTRIBUTES.each do |attribute|
-      value = public_send(attribute)
-      next if value.nil?
-
-      hash[attribute] = value
+    PROCESS_ATTRIBUTES.each_with_object({}) do |attribute, hash|
+      hash[attribute] = public_send(attribute)
     end
-    hash
   end
 
   def process


### PR DESCRIPTION
This is especially important with error_txt attribute