### PR TITLE
Limit stomp message retry to 3 times

### DIFF
--- a/app/services/send_update_message.rb
+++ b/app/services/send_update_message.rb
@@ -42,7 +42,8 @@ class SendUpdateMessage
                       start_timeout: 1,
                       connect_timeout: 1,
                       connread_timeout: 1,
-                      parse_timeout: 1)
+                      parse_timeout: 1,
+                      max_reconnect_attempts: 3)
   end
 
   def parse_failover_url(url)


### PR DESCRIPTION
The default was to retry forever.  When the STOMP server was unavailable
this may cause the process to hang