### PR TITLE
 Add a workflow list for all repositories 

### DIFF
--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -23,12 +23,17 @@ class WorkflowsController < ApplicationController
 
   # Display all steps for all versions of a given object
   def index
-    object_steps = WorkflowStep.where(repository: params[:repo], druid: params[:druid])
+    return redirect_to "/objects/#{params[:druid]}/workflows" if params[:repo]
+
+    object_steps = WorkflowStep.where(druid: params[:druid])
                                .order(:workflow, created_at: :asc)
                                .group_by(&:workflow)
 
     @workflows = object_steps.map do |wf_name, workflow_steps|
-      Workflow.new(name: wf_name, repository: params[:repo], druid: params[:druid], steps: workflow_steps)
+      Workflow.new(name: wf_name,
+                   repository: workflow_steps.first.repository,
+                   druid: params[:druid],
+                   steps: workflow_steps)
     end
   end
 

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -23,7 +23,11 @@ class WorkflowsController < ApplicationController
 
   # Display all steps for all versions of a given object
   def index
-    return redirect_to "/objects/#{params[:druid]}/workflows" if params[:repo]
+    # This ought to be a redirect, but our infrastructure is making it a
+    # challenge to do right now: https://github.com/sul-dlss/workflow-server-rails/pull/162#issuecomment-479191283
+    # so we'll just ignore an log it.
+    # return redirect_to "/objects/#{params[:druid]}/workflows" if params[:repo]
+    logger.warn 'Workflows#index with repo parameter is deprecated. Call /objects/:druid/workflows instead' if params[:repo]
 
     object_steps = WorkflowStep.where(druid: params[:druid])
                                .order(:workflow, created_at: :asc)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,10 @@ Rails.application.routes.draw do
     end
   end
 
+  scope 'objects/:druid', constraints: { druid: %r{[^\/]+} }, defaults: { format: :xml } do
+    resources :workflows, only: %i[index], param: :workflow
+  end
+
   get '/workflow_archive',
       to: 'workflows#archive',
       constraints: { druid: %r{[^\/]+} },

--- a/spec/requests/all_workflows_for_one_object_spec.rb
+++ b/spec/requests/all_workflows_for_one_object_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Get the steps for one object', type: :request do
     end
 
     it 'shows the error message' do
-      get "/dor/objects/#{druid}/workflows"
+      get "/objects/#{druid}/workflows"
       expect(response).to be_successful
       expect(response.body).to be_equivalent_to <<~XML
         <workflows objectId="#{druid}">
@@ -38,7 +38,7 @@ RSpec.describe 'Get the steps for one object', type: :request do
     end
 
     it 'does not have an error message' do
-      get "/dor/objects/#{druid}/workflows"
+      get "/objects/#{druid}/workflows"
       expect(response).to be_successful
       expect(response.body).to be_equivalent_to <<~XML
         <workflows objectId="#{druid}">
@@ -49,6 +49,15 @@ RSpec.describe 'Get the steps for one object', type: :request do
           </workflow>
         </workflows>
       XML
+    end
+  end
+
+  context 'the deprecated route with the repository' do
+    let(:druid) { 'abc:123' }
+
+    it 'redirects to the new route' do
+      get "/dor/objects/#{druid}/workflows"
+      expect(response).to redirect_to "/objects/#{druid}/workflows"
     end
   end
 end

--- a/spec/requests/all_workflows_for_one_object_spec.rb
+++ b/spec/requests/all_workflows_for_one_object_spec.rb
@@ -53,11 +53,27 @@ RSpec.describe 'Get the steps for one object', type: :request do
   end
 
   context 'the deprecated route with the repository' do
-    let(:druid) { 'abc:123' }
+    let(:item) do
+      FactoryBot.create(:workflow_step,
+                        status: 'completed',
+                        created_at: date)
+    end
 
     it 'redirects to the new route' do
       get "/dor/objects/#{druid}/workflows"
-      expect(response).to redirect_to "/objects/#{druid}/workflows"
+      # This ought to be a redirect, but our infrastructure is making it a
+      # challenge to do right now: https://github.com/sul-dlss/workflow-server-rails/pull/162#issuecomment-479191283
+      # expect(response).to redirect_to "/objects/#{druid}/workflows"
+      expect(response).to be_successful
+      expect(response.body).to be_equivalent_to <<~XML
+        <workflows objectId="#{druid}">
+          <workflow repository="dor" objectId="#{druid}" id="accessionWF">
+            <process version="1" priority="0" note="" lifecycle="" laneId="default"
+              elapsed="" attempts="0" datetime="#{date}"
+              status="completed" name="start-accession"/>
+          </workflow>
+        </workflows>
+      XML
     end
   end
 end


### PR DESCRIPTION
This is identical to #162, however the old route (with `/dor/` prefix) is not redirecting to the new route because our infrastructure (http proxy) will not support a redirect.