### PR TITLE
Reduce the number of queues to workflow x lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,34 @@
 
 This is a Rails-based workflow service that replaced SDR's Java-based workflow service.  It is consumed by the users of dor-workflow-client (argo, hydrus, hydra_etd, pre-assembly, dor-indexing-app, robots) and *soon* the goobi application (currently proxying through dor-services-app).
 
-## Build
+## Resque Jobs
+
+When a workflow step is set to done, the service calculates which workflow steps
+are ready to be worked on and enqueues Resque jobs for them.  The queues are named
+for the workflow and priority.  For example:
+
+```
+accessionWF_high
+accessionWF_default
+accessionWF_low
+assemblyWF_high
+assemblyWF_default
+assemblyWF_low
+disseminationWF_high
+disseminationWF_default
+disseminationWF_low
+...
+```
+
+## Developers
+
+### Build
 Build the production image
 ```
 docker build -t suldlss/workflow-server:latest .
 ```
 
-## Run the development stack
+### Run the development stack
 ```
 $ docker-compose up -d
 [FIRST RUN]

--- a/spec/services/queue_service_spec.rb
+++ b/spec/services/queue_service_spec.rb
@@ -12,27 +12,26 @@ RSpec.describe QueueService do
       allow(Resque).to receive(:enqueue_to)
     end
 
-    it 'enqueues to Resque and updates status' do
-      service.enqueue
-      expect(Resque).to have_received(:enqueue_to).with(:"dor_assemblyWF_jp2-create_default",
-                                                        'Robots::DorRepo::Assembly::Jp2Create', step.druid)
-      expect(step.status).to eq('queued')
+    context 'for JP2 robot (special case)' do
+      let(:step) { FactoryBot.create(:workflow_step, workflow: 'assemblyWF', process: 'jp2-create') }
+
+      it 'enqueues to Resque and updates status' do
+        service.enqueue
+        expect(Resque).to have_received(:enqueue_to).with('assemblyWF_jp2',
+                                                          'Robots::DorRepo::Assembly::Jp2Create', step.druid)
+        expect(step.status).to eq('queued')
+      end
     end
-  end
 
-  describe '#step_name' do
-    let(:step_name) { service.send(:step_name) }
+    context 'for other classes' do
+      let(:step) { FactoryBot.create(:workflow_step, workflow: 'accessionWF', process: 'descriptive-metadata') }
 
-    it 'create correct step_name' do
-      expect(step_name).to eq('dor:assemblyWF:jp2-create')
-    end
-  end
-
-  describe '#queue_name' do
-    let(:queue_name) { service.send(:queue_name) }
-
-    it 'create correct queue_name' do
-      expect(queue_name).to eq('dor_assemblyWF_jp2-create_default')
+      it 'enqueues to Resque and updates status' do
+        service.enqueue
+        expect(Resque).to have_received(:enqueue_to).with('accessionWF_default',
+                                                          'Robots::DorRepo::Accession::DescriptiveMetadata', step.druid)
+        expect(step.status).to eq('queued')
+      end
     end
   end
 


### PR DESCRIPTION
Prior to deploying, we need to update and deploy configuration for:
- [x] was_robots (https://github.com/sul-dlss/was_robot_suite/pull/124)
- [x] gis_robots (https://github.com/sul-dlss/gis-robot-suite/pull/198)
- [x] preservation_robots (https://github.com/sul-dlss/preservation_robots/pull/138)
- [x] common-assembly (https://github.com/sul-dlss/common-accessioning/pull/327)