### PR TITLE
Reduce unnecessary log messages

### DIFF
--- a/app/services/queue_service.rb
+++ b/app/services/queue_service.rb
@@ -19,7 +19,7 @@ class QueueService
   def enqueue
     # Perform the enqueue to Resque
     Resque.enqueue_to(queue_name.to_sym, class_name, step.druid)
-    Rails.logger.info "Enqueued #{class_name} for #{step.druid} to #{queue_name}"
+    Rails.logger.debug "Enqueued #{class_name} for #{step.druid} to #{queue_name}"
 
     # Update status
     step.update(status: 'queued')


### PR DESCRIPTION
Drop the level from info to debug.
This will get us fewer messages about the stale workflow steps