### PR TITLE
Add an endpoint to return the steps in a workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ PUT    /:repo/objects/:druid/workflows/:workflow/:process
 GET    /:repo/objects/:druid/workflows/:workflow/:process
 ```
 
+Return the list of steps for the given workflow template
+`GET   /workflow_templates/:workflow`
+
 `GET    /workflow_archive` - Deprecated. Currently just returns a count of the number of items/versions for the workflow
 `PUT    /:repo/objects/:druid/workflows/:workflow` - Deprecated. Use version without repo parameter instead.
 

--- a/app/controllers/workflow_templates_controller.rb
+++ b/app/controllers/workflow_templates_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Returns a representation of the workflow workflow_templates
+# This is used by argo so it can display the progress of an object
+# through the workflow.
+class WorkflowTemplatesController < ApplicationController
+  def show
+    template = WorkflowTemplateLoader.load_as_xml(params[:id])
+    parser = WorkflowTemplateParser.new(template)
+    @processes = parser.processes
+  end
+end

--- a/app/services/next_step_service.rb
+++ b/app/services/next_step_service.rb
@@ -25,7 +25,7 @@ class NextStepService
     todo = workflow(step.repository, step.workflow).except(*completed_steps)
 
     # Now filter by the steps that we have the prerequisites done for:
-    ready = todo.select { |_, val| (val[:prerequisites] - completed_steps).empty? && !val[:skip_queue] }.keys
+    ready = todo.select { |_, process| (process.prerequisites - completed_steps).empty? && !process.skip_queue }.keys
 
     steps.waiting.where(process: ready)
   end
@@ -36,15 +36,14 @@ class NextStepService
     @workflows[workflow] ||= load_workflow(repository, workflow)
   end
 
+  # @return [Hash<Process>]
   def load_workflow(repository, workflow)
     doc = WorkflowTemplateLoader.load_as_xml(workflow, repository)
     raise "Workflow #{workflow} not found" if doc.nil?
 
-    doc.xpath('/workflow-def/process').each_with_object({}) do |process, obj|
-      obj[process['name']] = {
-        prerequisites: process.xpath('prereq').map(&:text),
-        skip_queue: ActiveModel::Type::Boolean.new.cast(process['skip-queue'])
-      }
+    parser = WorkflowTemplateParser.new(doc)
+    parser.processes.each_with_object({}) do |process, obj|
+      obj[process.name] = process
     end
   end
 end

--- a/app/services/workflow_template_parser.rb
+++ b/app/services/workflow_template_parser.rb
@@ -4,6 +4,7 @@
 # Parsing workflow template
 class WorkflowTemplateParser
   attr_reader :workflow_doc
+  Process = Struct.new(:name, :label, :prerequisites, :skip_queue, keyword_init: true)
 
   # @param [Nokogiri::XML::Document] Workflow template as XML
   def initialize(workflow_doc)
@@ -20,7 +21,20 @@ class WorkflowTemplateParser
     end
   end
 
+  def processes
+    workflow.xpath('process').map { |process_node| build_process(process_node) }
+  end
+
   private
+
+  def build_process(process_node)
+    Process.new(
+      name: process_node['name'],
+      label: process_node.xpath('label').text,
+      prerequisites: process_node.xpath('prereq').map(&:text),
+      skip_queue: ActiveModel::Type::Boolean.new.cast(process_node['skip-queue'])
+    )
+  end
 
   def workflow
     workflow_doc.xpath('//workflow-def')

--- a/app/views/workflow_templates/show.json.jbuilder
+++ b/app/views/workflow_templates/show.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.processes @processes, :name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :workflow_templates, only: [:show], defaults: { format: :json }
+
   get '/workflow_archive',
       to: 'workflows#archive',
       constraints: { druid: %r{[^\/]+} },

--- a/spec/requests/show_workflow_template_spec.rb
+++ b/spec/requests/show_workflow_template_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Show a workflow template', type: :request do
+  it 'draws an empty set of milestones' do
+    get '/workflow_templates/assemblyWF'
+    json = JSON.parse(response.body)
+    expect(json['processes']).to eq [{ 'name' => 'start-assembly' },
+                                     { 'name' => 'content-metadata-create' },
+                                     { 'name' => 'jp2-create' },
+                                     { 'name' => 'checksum-compute' },
+                                     { 'name' => 'exif-collect' },
+                                     { 'name' => 'accessioning-initiate' }]
+  end
+end

--- a/spec/services/workflow_template_parser_spec.rb
+++ b/spec/services/workflow_template_parser_spec.rb
@@ -29,4 +29,13 @@ RSpec.describe WorkflowTemplateParser do
       end
     end
   end
+
+  describe '#processes' do
+    subject(:processes) { wf_parser.processes }
+
+    it 'returns a list of process structs' do
+      expect(processes.length).to eq 13
+      expect(processes).to all(be_an_instance_of(WorkflowTemplateParser::Process))
+    end
+  end
 end


### PR DESCRIPTION
This will be used by Argo so that workflow objects don't need to exist in Fedora