### PR TITLE
Allow updating a workflow step without a repo.

### DIFF
--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -16,6 +16,8 @@ class StepsController < ApplicationController
 
     return render plain: status_mismatch_error(step), status: :conflict if params['current-status'] && step.status != params['current-status']
 
+    Honeybadger.notify('There is no need to pass "repo" parameter to update a workflow step.') if params[:repo]
+
     step.update(parser.to_h)
 
     # Enqueue next steps
@@ -55,7 +57,6 @@ class StepsController < ApplicationController
   # Returns most recent workflow step
   def find_step_for_process
     WorkflowStep.order(version: :desc).find_by(
-      repository: params[:repo],
       druid: params[:druid],
       workflow: params[:workflow],
       process: params[:process]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
       collection do
         # Create should be a POST, but this is what the Java WFS app did.
         put ':workflow', to: 'workflows#deprecated_create'
-        put ':workflow/:process', to: 'steps#update'
+        put ':workflow/:process', to: 'steps#update' # deprecated
         get ':workflow/:process', to: 'steps#show'
       end
     end
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
     resources :workflows, only: %i[index], param: :workflow do
       collection do
         post ':workflow', to: 'workflows#create'
+        put ':workflow/:process', to: 'steps#update'
       end
     end
   end


### PR DESCRIPTION
Since all our workflow names are unique, there's no need to make repository part of the key