### PR TITLE
Add postgres client install to circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,8 @@ jobs:
             curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
             chmod +x ./cc-test-reporter
 
+    - run: sudo apt update && sudo apt install -y postgresql-client || true
+
     - run:
         name: Wait for DB
         command: dockerize -wait tcp://localhost:5432 -timeout 1m


### PR DESCRIPTION
Add discovered in work with dor-services-app, the postgres client needed to be installed for the circleci tests to run successfully.

(No, I don't know why they were green before.)