### PR TITLE
Return a list of workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ PUT    /:repo/objects/:druid/workflows/:workflow/:process
 GET    /:repo/objects/:druid/workflows/:workflow/:process
 ```
 
+Return the list of workflow templates
+`GET   /workflow_templates`
+
 Return the list of steps for the given workflow template
 `GET   /workflow_templates/:workflow`
 

--- a/app/controllers/workflow_templates_controller.rb
+++ b/app/controllers/workflow_templates_controller.rb
@@ -12,4 +12,10 @@ class WorkflowTemplatesController < ApplicationController
     parser = WorkflowTemplateParser.new(template)
     @processes = parser.processes
   end
+
+  def index
+    files = Dir.glob("#{WorkflowTemplateLoader::WORKFLOWS_DIR}/**/*.xml")
+    names = files.map { |file| file.sub(%r{#{WorkflowTemplateLoader::WORKFLOWS_DIR}/[^/]*/([^\/]*).xml}, '\1') }.sort
+    render json: names
+  end
 end

--- a/app/services/workflow_template_loader.rb
+++ b/app/services/workflow_template_loader.rb
@@ -3,6 +3,7 @@
 ##
 # Loading workflow templates
 class WorkflowTemplateLoader
+  WORKFLOWS_DIR = 'config/workflows'
   # Loads a workflow template from file
   # @param [String] workflow_name name/id of workflow, e.g., accessionWF
   # @param [String] optional repository (sdr or dor). If not provided, will guess.
@@ -61,6 +62,6 @@ class WorkflowTemplateLoader
   end
 
   def construct_filepath(repository)
-    "config/workflows/#{repository}/#{workflow_name}.xml"
+    "#{WORKFLOWS_DIR}/#{repository}/#{workflow_name}.xml"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :workflow_templates, only: [:show], defaults: { format: :json }
+  resources :workflow_templates, only: %i[show index], defaults: { format: :json }
 
   get '/workflow_archive',
       to: 'workflows#archive',

--- a/spec/requests/list_workflow_templates_spec.rb
+++ b/spec/requests/list_workflow_templates_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'List the workflow templates', type: :request do
+  it 'draws name and label' do
+    get '/workflow_templates'
+    expect(response).to have_http_status(:ok)
+    json = JSON.parse(response.body)
+    expect(json).to eq %w[
+      accessionWF
+      assemblyWF
+      digitizationWF
+      disseminationWF
+      etdSubmitWF
+      gisAssemblyWF
+      gisDeliveryWF
+      gisDiscoveryWF
+      goobiWF
+      hydrusAssemblyWF
+      preservationAuditWF
+      preservationIngestWF
+      registrationWF
+      releaseWF
+      sdrIngestWF
+      versioningWF
+      wasCrawlDisseminationWF
+      wasCrawlPreassemblyWF
+      wasDisseminationWF
+      wasSeedDisseminationWF
+      wasSeedPreassemblyWF
+    ]
+  end
+end


### PR DESCRIPTION
So that argo can provide a chooser of available workflows when setting up an APO.
Ref https://github.com/sul-dlss/argo/issues/1578#issuecomment-533581595