### PR TITLE
Add a publish callback to the release workflow

### DIFF
--- a/config/workflows/dor/releaseWF.xml
+++ b/config/workflows/dor/releaseWF.xml
@@ -11,7 +11,10 @@
     <prereq>release-members</prereq>
     <label>Determines which items to republish</label>
   </process>
-  <process name="update-marc" sequence="4">
+  <process name="publish-complete" sequence="4" skip-queue="true">
+    <label>Signal that object has been published</label>
+  </process>
+  <process name="publish-complete" sequence="5">
     <prereq>release-publish</prereq>
     <label>Generates Symphony record with PURL URI</label>
   </process>


### PR DESCRIPTION
## Why was this change made?
So that the release workflow can be notified that published is complete.

## Was the documentation (API, README, DevOpsDocs, wiki, consul, etc.) updated?
 n/a