### PR TITLE
WorkflowStep: require repository

### DIFF
--- a/app/models/workflow_step.rb
+++ b/app/models/workflow_step.rb
@@ -6,6 +6,7 @@ class WorkflowStep < ApplicationRecord
   validates :workflow, presence: true
   validates :process, presence: true
   validates :version, presence: true
+  validates :repository, presence: true
 
   scope :lifecycle, -> { where.not(lifecycle: nil) }
   scope :incomplete, -> { where.not(status: %w[completed skipped]) }


### PR DESCRIPTION
## Why was this change made?

we don't ever want `repository` to be null in the DB.  we should add a DB constraint, but this is a first step before cleaning up existing data.

## Was the documentation (API, README, DevOpsDocs, wiki, consul, etc.) updated?
n/a