### PR TITLE
Add indexes for queries without repository

### DIFF
--- a/db/migrate/20191113200233_add_indexes_without_repository.rb
+++ b/db/migrate/20191113200233_add_indexes_without_repository.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddIndexesWithoutRepository < ActiveRecord::Migration[5.2]
+  def change
+    add_index :workflow_steps, %i[active_version status workflow process], name: 'active_version_step_name_workflow2_idx'
+    add_index :workflow_steps, %i[status workflow process druid], name: 'step_name_with_druid_workflow2_idx'
+    add_index :workflow_steps, %i[status workflow process], name: 'step_name_workflow2_idx'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_17_154458) do
+ActiveRecord::Schema.define(version: 2019_11_13_200233) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,10 +33,13 @@ ActiveRecord::Schema.define(version: 2019_05_17_154458) do
     t.datetime "updated_at", null: false
     t.boolean "active_version", default: false
     t.index ["active_version", "status", "workflow", "process", "repository"], name: "active_version_step_name_workflow_idx"
+    t.index ["active_version", "status", "workflow", "process"], name: "active_version_step_name_workflow2_idx"
     t.index ["druid", "version"], name: "index_workflow_steps_on_druid_and_version"
     t.index ["druid"], name: "index_workflow_steps_on_druid"
+    t.index ["status", "workflow", "process", "druid"], name: "step_name_with_druid_workflow2_idx"
     t.index ["status", "workflow", "process", "repository", "druid"], name: "step_name_with_druid_workflow_idx"
     t.index ["status", "workflow", "process", "repository"], name: "step_name_workflow_idx"
+    t.index ["status", "workflow", "process"], name: "step_name_workflow2_idx"
   end
 
 end


### PR DESCRIPTION
NOTE: This table is *huge*, it may take a long time to create these indexes


## Why was this change made?
This will allow us to drop the repository column in the future. This column is unnecessary as `workflow` alone is enough to differentiate the workflows.

## Was the documentation (API, README, DevOpsDocs, wiki, consul, etc.) updated?
n/a