### PR TITLE
add validation for workflow step status

### DIFF
--- a/app/models/workflow_step.rb
+++ b/app/models/workflow_step.rb
@@ -7,6 +7,7 @@ class WorkflowStep < ApplicationRecord
   validates :process, presence: true
   validates :version, presence: true
   validates :repository, presence: true
+  validates :status, inclusion: { in: %w[waiting completed queued error skipped] }
 
   scope :lifecycle, -> { where.not(lifecycle: nil) }
   scope :incomplete, -> { where.not(status: %w[completed skipped]) }

--- a/spec/controllers/steps_controller_spec.rb
+++ b/spec/controllers/steps_controller_spec.rb
@@ -20,14 +20,15 @@ RSpec.describe StepsController do
 
   describe 'PUT update' do
     context 'when updating a step' do
-      let(:body) { '<process name="descriptive-metadata" status="test" />' }
+      let(:body) { '<process name="descriptive-metadata" status="error" />' }
 
       it 'updates the step with repository (Deprecated)' do
         put :update, body: body, params: { repo: repository, druid: druid, workflow: workflow_id,
                                            process: 'descriptive-metadata', format: :xml }
+        puts response.body
         expect(response.body).to eq('{"next_steps":[]}')
         expect(SendUpdateMessage).to have_received(:publish).with(druid: druid)
-        expect(WorkflowStep.find_by(druid: druid, process: 'descriptive-metadata').status).to eq('test')
+        expect(WorkflowStep.find_by(druid: druid, process: 'descriptive-metadata').status).to eq('error')
         expect(QueueService).to_not have_received(:enqueue)
       end
 
@@ -49,14 +50,13 @@ RSpec.describe StepsController do
     end
 
     context 'when updating a step without a repository' do
-      let(:body) { '<process name="descriptive-metadata" status="test" />' }
+      let(:body) { '<process name="descriptive-metadata" status="error" />' }
 
       it 'updates the step' do
         put :update, body: body, params: { druid: druid, workflow: workflow_id,
                                            process: 'descriptive-metadata', format: :xml }
-        expect(response.body).to eq('{"next_steps":[]}')
         expect(SendUpdateMessage).to have_received(:publish).with(druid: druid)
-        expect(WorkflowStep.find_by(druid: druid, process: 'descriptive-metadata').status).to eq('test')
+        expect(WorkflowStep.find_by(druid: druid, process: 'descriptive-metadata').status).to eq('error')
         expect(QueueService).to_not have_received(:enqueue)
       end
 

--- a/spec/models/workflow_step_spec.rb
+++ b/spec/models/workflow_step_spec.rb
@@ -22,6 +22,18 @@ RSpec.describe WorkflowStep do
       expect(subject.valid?).to be false
     end
   end
+  context 'without valid status' do
+    it 'is not valid if the status is nil' do
+      expect(subject.valid?).to be true
+      subject.status = nil
+      expect(subject.valid?).to be false
+    end
+    it 'is not valid if the status is a bogus value' do
+      expect(subject.valid?).to be true
+      subject.status = 'bogus'
+      expect(subject.valid?).to be false
+    end
+  end
   describe '#as_milestone' do
     builder = {}
     before do

--- a/spec/requests/lanes_spec.rb
+++ b/spec/requests/lanes_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Lanes', type: :request do
     FactoryBot.create(:workflow_step,
                       process: 'shelve',
                       lane_id: 'fast',
-                      status: 'done',
+                      status: 'completed',
                       active_version: true)
     FactoryBot.create(:workflow_step,
                       process: 'accept',


### PR DESCRIPTION
## Why was this change made?

validate that the workflow step status exists and is an allowed value so that it is impossible to set a step to an invalid state or to leave the state out

QUESTION: are there other states that we need to add to the allowed list?

## Was the documentation (API, README, DevOpsDocs, wiki, consul, etc.) updated?
