### PR TITLE
validate version in workflow step

### DIFF
--- a/app/models/workflow_step.rb
+++ b/app/models/workflow_step.rb
@@ -5,7 +5,7 @@ class WorkflowStep < ApplicationRecord
   validates :druid, presence: true
   validates :workflow, presence: true
   validates :process, presence: true
-  validates :version, presence: true
+  validates :version, numericality: { only_integer: true }
   validates :repository, presence: true
   validates :status, inclusion: { in: %w[waiting completed queued error skipped] }
   validates :process, uniqueness: { scope: %w[version workflow druid] }

--- a/spec/controllers/steps_controller_spec.rb
+++ b/spec/controllers/steps_controller_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe StepsController do
       it 'updates the step with repository (Deprecated)' do
         put :update, body: body, params: { repo: repository, druid: druid, workflow: workflow_id,
                                            process: 'descriptive-metadata', format: :xml }
-        puts response.body
         expect(response.body).to eq('{"next_steps":[]}')
         expect(SendUpdateMessage).to have_received(:publish).with(druid: druid)
         expect(WorkflowStep.find_by(druid: druid, process: 'descriptive-metadata').status).to eq('error')

--- a/spec/models/workflow_step_spec.rb
+++ b/spec/models/workflow_step_spec.rb
@@ -48,6 +48,22 @@ RSpec.describe WorkflowStep do
       expect(dupe_step.errors.messages).to include(process: ['has already been taken'])
     end
   end
+  context 'without valid version' do
+    it 'is not valid if the version is nil' do
+      expect(subject.valid?).to be true
+      subject.version = nil
+      expect(subject.valid?).to be false
+    end
+    it 'is not valid if the version is not an integer' do
+      expect(subject.valid?).to be true
+      subject.version = 'bogus'
+      expect(subject.valid?).to be false
+      subject.version = 4.3
+      expect(subject.valid?).to be false
+      subject.version = ''
+      expect(subject.valid?).to be false
+    end
+  end
   describe '#as_milestone' do
     builder = {}
     before do


### PR DESCRIPTION
## Why was this change made?

just continue down the path of validating step data so we can't create bad data 

## Was the documentation (API, README, DevOpsDocs, wiki, consul, etc.) updated?
