### PR TITLE
when creating workflow steps, ensure they have valid workflow name and process

### DIFF
--- a/spec/models/workflow_step_spec.rb
+++ b/spec/models/workflow_step_spec.rb
@@ -48,6 +48,38 @@ RSpec.describe WorkflowStep do
       expect(dupe_step.errors.messages).to include(process: ['has already been taken'])
     end
   end
+  context 'without valid workflow name' do
+    it 'is not possible to create a new workflow step for a non-existent or missing workflow value' do
+      bogus_workflow = described_class.new(
+        druid: subject.druid,
+        workflow: 'bogusWF',
+        process: subject.process,
+        version: subject.version,
+        status: subject.status,
+        repository: subject.repository
+      )
+      expect(bogus_workflow.valid?).to be false
+      expect(bogus_workflow.errors.messages).to include(workflow: ['is not valid'])
+      bogus_workflow.workflow = nil
+      expect(bogus_workflow.valid?).to be false
+    end
+  end
+  context 'without valid process name' do
+    it 'is not possible to create a new workflow step for a non-existent or missing process value' do
+      bogus_process = described_class.new(
+        druid: subject.druid,
+        workflow: subject.workflow,
+        process: 'bogus-step',
+        version: subject.version,
+        status: subject.status,
+        repository: subject.repository
+      )
+      expect(bogus_process.valid?).to be false
+      expect(bogus_process.errors.messages).to include(process: ['is not valid'])
+      bogus_process.process = nil
+      expect(bogus_process.valid?).to be false
+    end
+  end
   context 'without valid version' do
     it 'is not valid if the version is nil' do
       expect(subject.valid?).to be true

--- a/spec/requests/lanes_spec.rb
+++ b/spec/requests/lanes_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Lanes', type: :request do
                       status: 'completed',
                       active_version: true)
     FactoryBot.create(:workflow_step,
-                      process: 'accept',
+                      process: 'shelve-complete',
                       lane_id: 'fast',
                       status: 'waiting',
                       active_version: true)

--- a/spec/requests/lifecycle_spec.rb
+++ b/spec/requests/lifecycle_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Lifecycle', type: :request do
     let(:wf) do
       # This should not appear in the results if they want active-only
       FactoryBot.create(:workflow_step,
-                        process: 'opened',
+                        process: 'start-accession',
                         version: 1,
                         status: 'waiting',
                         lifecycle: 'submitted')
@@ -34,7 +34,7 @@ RSpec.describe 'Lifecycle', type: :request do
         FactoryBot.create(:workflow_step,
                           druid: druid,
                           version: 2,
-                          process: 'verify-agreement',
+                          process: 'remediate-object',
                           status: 'completed')
         allow(Dor::Services::Client).to receive(:object).with(druid).and_return(client)
       end
@@ -59,7 +59,7 @@ RSpec.describe 'Lifecycle', type: :request do
         FactoryBot.create(:workflow_step,
                           druid: druid,
                           version: 2,
-                          process: 'verify-agreement',
+                          process: 'remediate-object',
                           status: 'waiting')
         allow(Dor::Services::Client).to receive(:object).with(druid).and_return(client)
       end
@@ -76,7 +76,7 @@ RSpec.describe 'Lifecycle', type: :request do
   context 'when active-only is not set' do
     let(:wf) do
       FactoryBot.create(:workflow_step,
-                        process: 'opened',
+                        process: 'start-accession',
                         version: 1,
                         lane_id: 'default',
                         status: 'completed',
@@ -87,7 +87,7 @@ RSpec.describe 'Lifecycle', type: :request do
       FactoryBot.create(:workflow_step,
                         druid: druid,
                         version: 2,
-                        process: 'opened',
+                        process: 'start-accession',
                         status: 'completed',
                         lifecycle: 'submitted')
 
@@ -95,7 +95,7 @@ RSpec.describe 'Lifecycle', type: :request do
       FactoryBot.create(:workflow_step,
                         druid: druid,
                         version: 2,
-                        process: 'start-accession',
+                        process: 'rights-metadata',
                         lane_id: 'fast',
                         status: 'completed')
 
@@ -103,7 +103,7 @@ RSpec.describe 'Lifecycle', type: :request do
       FactoryBot.create(:workflow_step,
                         druid: druid,
                         version: 2,
-                        process: 'index',
+                        process: 'sdr-ingest-transfer',
                         status: 'waiting',
                         lifecycle: 'indexed')
     end

--- a/spec/requests/queues/all_queued_spec.rb
+++ b/spec/requests/queues/all_queued_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'All queued steps', type: :request do
 
   let!(:two) do
     FactoryBot.create(:workflow_step,
-                      process: 'accept',
+                      process: 'shelve-complete',
                       lane_id: 'fast',
                       status: 'queued',
                       updated_at: 3.days.ago)
@@ -38,7 +38,7 @@ RSpec.describe 'All queued steps', type: :request do
     expect(response.body).to be_equivalent_to <<~XML
       <workflows>
         <workflow name="accessionWF" process="shelve" druid="#{one.druid}" laneId="default"/>
-        <workflow name="accessionWF" process="accept" druid="#{two.druid}" laneId="fast"/>
+        <workflow name="accessionWF" process="shelve-complete" druid="#{two.druid}" laneId="fast"/>
       </workflows>
     XML
   end


### PR DESCRIPTION
## Why was this change made?

Prevent bad data from being created during remediation or other manual interventions by confirming that we can only create a new workflow row for an existing defined workflow, and that the step name provided is actually defined in the named workflow.  It is not necessary to perform this validation on update (and may be undesirable to do so) because it is theoretically possible for an existing workflow step name or workflow itself to change/be removed and still need to be updated later.

Note this validation is mostly there to protect from the sorts of manual remediations we are performing, as the creation of steps should in theory be undertaken only indirectly (when you ask the service to create an entire new workflow at once, where it then creates each step in process).

Note that there is a penalty cost to performing this validation when creating steps (namely, looking for the existence of the XML file and then parsing a struct) but I think it should be fast.

## Was the documentation (API, README, DevOpsDocs, wiki, consul, etc.) updated?
