### PR TITLE
Deprecate passing repo to the show route

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -6,7 +6,7 @@ class Workflow
   # @param druid [String] the identifier for the object
   # @param repository [String] the identifier of the repository (e.g. 'dor')
   # @param steps [Array<WorkflowStep>] the steps that belong to this workflow
-  def initialize(name:, druid:, repository:, steps: [])
+  def initialize(name:, druid:, repository: nil, steps: [])
     @name = name
     @druid = druid
     @repository = repository

--- a/app/views/workflows/_workflow.xml.builder
+++ b/app/views/workflows/_workflow.xml.builder
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
-builder.workflow(repository: workflow.repository, objectId: workflow.druid, id: workflow.name) do
+workflow_props = { objectId: workflow.druid, id: workflow.name }
+workflow_props.merge!(repository: workflow.repository) if workflow.repository
+builder.workflow(workflow_props) do
   render(partial: 'process', collection: workflow.steps, locals: { builder: builder })
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,8 @@ Rails.application.routes.draw do
     post 'versionClose', to: 'versions#close'
 
     # NOTE: the index route /dor/objects/:druid/workflows is encoded in the dsLocation of the workflows
-    # datastream (external type) for all of our Fedora 3 objects.  We shouldn't change this endpoint.
+    # datastream (external type) for all of our Fedora 3 objects, so we shouldn't
+    # change this endpoint until we get rid of the workflows as a datastream.
     resources :workflows, only: %i[show index destroy], param: :workflow do
       collection do
         # Create should be a POST, but this is what the Java WFS app did.
@@ -19,7 +20,7 @@ Rails.application.routes.draw do
 
   scope 'objects/:druid', constraints: { druid: %r{[^\/]+} }, defaults: { format: :xml } do
     delete 'workflows', to: 'steps#destroy_all'
-    resources :workflows, only: %i[index], param: :workflow do
+    resources :workflows, only: %i[show index], param: :workflow do
       collection do
         post ':workflow', to: 'workflows#create'
         put ':workflow/:process', to: 'steps#update'

--- a/spec/requests/workflows/single_workflow_for_object_spec.rb
+++ b/spec/requests/workflows/single_workflow_for_object_spec.rb
@@ -3,38 +3,77 @@
 require 'rails_helper'
 
 RSpec.describe 'Get a single workflow for an object', type: :request do
-  context 'when a workflow exists for the object' do
-    let(:item) do
-      FactoryBot.create(:workflow_step,
-                        status: 'waiting',
-                        created_at: date)
+  context 'when repo is supplied (deprecated)' do
+    context 'when a workflow exists for the object' do
+      let(:item) do
+        FactoryBot.create(:workflow_step,
+                          status: 'waiting',
+                          created_at: date)
+      end
+
+      let(:date) { Time.now.utc.iso8601.sub(/Z/, '+00:00') }
+      let(:druid) { item.druid }
+
+      it 'shows the workflow' do
+        get "/dor/objects/#{druid}/workflows/accessionWF"
+        expect(response).to be_successful
+        expect(response.body).to be_equivalent_to <<~XML
+          <workflow repository="dor" objectId="#{druid}" id="accessionWF">
+            <process version="1" note="" lifecycle="" laneId="default"
+              elapsed="" attempts="0" datetime="#{date}"
+              status="waiting" name="start-accession"/>
+          </workflow>
+        XML
+      end
     end
 
-    let(:date) { Time.now.utc.iso8601.sub(/Z/, '+00:00') }
-    let(:druid) { item.druid }
+    context 'when no workflow exists' do
+      let(:druid) { 'druid:abc1232' }
 
-    it 'shows the workflow' do
-      get "/dor/objects/#{druid}/workflows/accessionWF"
-      expect(response).to be_successful
-      expect(response.body).to be_equivalent_to <<~XML
-        <workflow repository="dor" objectId="#{druid}" id="accessionWF">
-          <process version="1" note="" lifecycle="" laneId="default"
-            elapsed="" attempts="0" datetime="#{date}"
-            status="waiting" name="start-accession"/>
-        </workflow>
-      XML
+      it 'returns an empy workflow node' do
+        get "/dor/objects/#{druid}/workflows/accessionWF"
+        expect(response).to be_successful
+        expect(response.body).to be_equivalent_to <<~XML
+          <workflow repository="dor" objectId="#{druid}" id="accessionWF" />
+        XML
+      end
     end
   end
 
-  context 'when no workflow exists' do
-    let(:druid) { 'druid:abc1232' }
+  context 'when repo is not supplied' do
+    context 'when a workflow exists for the object' do
+      let(:item) do
+        FactoryBot.create(:workflow_step,
+                          status: 'waiting',
+                          created_at: date)
+      end
 
-    it 'returns an empy workflow node' do
-      get "/dor/objects/#{druid}/workflows/accessionWF"
-      expect(response).to be_successful
-      expect(response.body).to be_equivalent_to <<~XML
-        <workflow repository="dor" objectId="#{druid}" id="accessionWF" />
-      XML
+      let(:date) { Time.now.utc.iso8601.sub(/Z/, '+00:00') }
+      let(:druid) { item.druid }
+
+      it 'shows the workflow' do
+        get "/objects/#{druid}/workflows/accessionWF"
+        expect(response).to be_successful
+        expect(response.body).to be_equivalent_to <<~XML
+          <workflow objectId="#{druid}" id="accessionWF">
+            <process version="1" note="" lifecycle="" laneId="default"
+              elapsed="" attempts="0" datetime="#{date}"
+              status="waiting" name="start-accession"/>
+          </workflow>
+        XML
+      end
+    end
+
+    context 'when no workflow exists' do
+      let(:druid) { 'druid:abc1232' }
+
+      it 'returns an empy workflow node' do
+        get "/objects/#{druid}/workflows/accessionWF"
+        expect(response).to be_successful
+        expect(response.body).to be_equivalent_to <<~XML
+          <workflow objectId="#{druid}" id="accessionWF" />
+        XML
+      end
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

Allows our consumers to get ready for #278 

## Was the documentation (API, README, DevOpsDocs, wiki, consul, etc.) updated?
n/a