### PR TITLE
Use docker volume for postgres data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,4 @@ config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
 
-/postgres-data/*
-
 /coverage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.6'
 
 services:
   app:
@@ -21,8 +21,6 @@ services:
       - "3000:3000"
     depends_on:
       - db
-    networks:
-      - wfs
   db:
     image: postgres
     ports:
@@ -30,14 +28,10 @@ services:
     environment:
       - POSTGRES_PASSWORD=sekret
     volumes:
-      - ./postgres-data:/var/lib/postgresql/data
-    networks:
-      - wfs
+      - postgres-data:/var/lib/postgresql/data
   redis:
     image: redis
     ports:
       - "6379:6379"
-    networks:
-      - wfs
-networks:
-  wfs:
+volumes:
+  postgres-data:


### PR DESCRIPTION
And stop older-style network setup

## Why was this change made?

To prevent creating an unnecessary postgres-data dir locally and remove cruft

## Was the documentation (API, README, DevOpsDocs, wiki, consul, etc.) updated?

no