### PR TITLE
Add a callback for preservation ingest

### DIFF
--- a/config/workflows/dor/accessionWF.xml
+++ b/config/workflows/dor/accessionWF.xml
@@ -45,16 +45,19 @@
     <label>Initiate Ingest into Preservation</label>
     <prereq>provenance-metadata</prereq>
   </process>
-  <process batch-limit="1" error-limit="5" lifecycle="deposited" name="sdr-ingest-received" sequence="13" skip-queue="true">
+  <process batch-limit="1" error-limit="5" name="preservation-ingest-initiated" sequence="13" skip-queue="true">
+    <label>Signal that preservation ingest has been initiated</label>
+  </process>
+  <process batch-limit="1" error-limit="5" lifecycle="deposited" name="sdr-ingest-received" sequence="14" skip-queue="true">
     <label>Signal from SDR that object has been received</label>
   </process>
-  <process batch-limit="1" error-limit="5" name="reset-workspace" sequence="14">
+  <process batch-limit="1" error-limit="5" name="reset-workspace" sequence="15">
     <label>Reset workspace by renaming the druid-tree to a versioned directory</label>
     <prereq>sdr-ingest-received</prereq>
     <prereq>provenance-metadata</prereq>
     <prereq>shelve-complete</prereq>
   </process>
-  <process batch-limit="1" error-limit="5" lifecycle="accessioned" name="end-accession" sequence="15">
+  <process batch-limit="1" error-limit="5" lifecycle="accessioned" name="end-accession" sequence="16">
     <label>Clean up any diff caches and set disseminationWF:cleanup to waiting</label>
     <prereq>reset-workspace</prereq>
   </process>

--- a/spec/controllers/workflows_controller_spec.rb
+++ b/spec/controllers/workflows_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe WorkflowsController do
       it 'creates new workflows' do
         expect do
           put :deprecated_create, body: request_data, params: { repo: repository, druid: druid, workflow: workflow, format: :xml }
-        end.to change(WorkflowStep, :count).by(15)
+        end.to change(WorkflowStep, :count).by(16)
 
         expect(SendUpdateMessage).to have_received(:publish).with(druid: druid)
       end
@@ -54,7 +54,7 @@ RSpec.describe WorkflowsController do
         it 'returns a 400 error' do
           expect do
             put :deprecated_create, body: request_data, params: { repo: repository, druid: druid, workflow: workflow, format: :xml }
-          end.to change(WorkflowStep, :count).by(15)
+          end.to change(WorkflowStep, :count).by(16)
         end
       end
     end
@@ -69,7 +69,7 @@ RSpec.describe WorkflowsController do
       it 'creates new workflows' do
         expect do
           put :deprecated_create, body: request_data, params: { repo: repository, druid: druid, workflow: workflow, format: :xml }
-        end.to change(WorkflowStep, :count).by(15)
+        end.to change(WorkflowStep, :count).by(16)
 
         expect(SendUpdateMessage).to have_received(:publish).with(druid: druid)
       end
@@ -89,7 +89,7 @@ RSpec.describe WorkflowsController do
       it 'creates new workflows' do
         expect do
           post :create, params: { druid: druid, workflow: workflow, format: :xml }
-        end.to change(WorkflowStep, :count).by(15)
+        end.to change(WorkflowStep, :count).by(16)
         expect(WorkflowStep.last.lane_id).to eq('default')
         expect(SendUpdateMessage).to have_received(:publish).with(druid: druid)
       end
@@ -120,7 +120,7 @@ RSpec.describe WorkflowsController do
       it 'creates new workflows' do
         expect do
           post :create, params: { druid: druid, workflow: workflow, format: :xml }
-        end.to change(WorkflowStep, :count).by(15)
+        end.to change(WorkflowStep, :count).by(16)
 
         expect(SendUpdateMessage).to have_received(:publish).with(druid: druid)
       end

--- a/spec/requests/version_close_spec.rb
+++ b/spec/requests/version_close_spec.rb
@@ -15,6 +15,6 @@ RSpec.describe 'Close a version', type: :request do
   it 'closes the version' do
     post "/dor/objects/#{druid}/versionClose"
     expect(response).to be_successful
-    expect(WorkflowStep.where(druid: druid).count).to eq 15
+    expect(WorkflowStep.where(druid: druid).count).to eq 16
   end
 end

--- a/spec/services/initial_workflow_parser_spec.rb
+++ b/spec/services/initial_workflow_parser_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe InitialWorkflowParser do
 
     it 'is a list of ProcessParsers' do
       expect(processes).to all be_instance_of ProcessParser
-      expect(processes.size).to eq 15
+      expect(processes.size).to eq 16
     end
   end
 end

--- a/spec/services/workflow_creator_spec.rb
+++ b/spec/services/workflow_creator_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe WorkflowCreator do
     it 'creates a WorkflowStep for each process' do
       expect do
         create_workflow_steps
-      end.to change(WorkflowStep, :count).by(15)
+      end.to change(WorkflowStep, :count).by(16)
       expect(WorkflowStep.last.druid).to eq druid
       expect(WorkflowStep.last.repository).to eq repository
       expect(QueueService).to have_received(:enqueue).with(WorkflowStep.find_by(druid: druid, process: 'descriptive-metadata'))

--- a/spec/services/workflow_template_parser_spec.rb
+++ b/spec/services/workflow_template_parser_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe WorkflowTemplateParser do
     subject(:processes) { wf_parser.processes }
 
     it 'returns a list of process structs' do
-      expect(processes.length).to eq 15
+      expect(processes.length).to eq 16
       expect(processes).to all(be_an_instance_of(WorkflowTemplateParser::Process))
     end
   end

--- a/spec/services/workflow_transformer_spec.rb
+++ b/spec/services/workflow_transformer_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe WorkflowTransformer do
           <process name="publish-complete" status="waiting" lifecycle="published"/>
           <process name="provenance-metadata" status="waiting"/>
           <process name="sdr-ingest-transfer" status="waiting"/>
+          <process name="preservation-ingest-initiated" status="waiting"/>
           <process name="sdr-ingest-received" status="waiting" lifecycle="deposited"/>
           <process name="reset-workspace" status="waiting"/>
           <process name="end-accession" status="waiting" lifecycle="accessioned"/>


### PR DESCRIPTION

## Why was this change made?

We will soon move SdrIngestTransfer to dor-services-app.  As this can take a long time, it will be performed in the background. This new workflow step will be able to log that that process completed successfully.

As nothing depends on this step (progress is blocked by sdr-ingest-received), this should not prevent any items from progressing through the workflow.  If we add this step to the template in prior to updating it (from dor-services-app), we will have to do less remediation of items currently in error somewhere in the workflow.

## Was the documentation (API, README, DevOpsDocs, wiki, consul, etc.) updated?
n/a