### PR TITLE
Quiet honeybadger

### DIFF
--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -42,7 +42,6 @@ class WorkflowsController < ApplicationController
   end
 
   # Display all steps for all workflows for all versions of a given object
-  # rubocop:disable Metrics/MethodLength
   def show
     workflow_props = { name: params[:workflow], druid: params[:druid] }
     scope = WorkflowStep.where(
@@ -50,7 +49,6 @@ class WorkflowsController < ApplicationController
       workflow: params[:workflow]
     )
     if params[:repo]
-      Honeybadger.notify('The repository parameter was passed, but this is not necessary')
       scope.where(repository: params[:repo])
       workflow_props[:repository] = params[:repo]
     end
@@ -58,7 +56,6 @@ class WorkflowsController < ApplicationController
 
     @workflow = Workflow.new(workflow_props.merge(steps: workflow_steps))
   end
-  # rubocop:enable Metrics/MethodLength
 
   def destroy
     obj = Version.new(


### PR DESCRIPTION


## Why was this change made?

Stop creating alerts for the unused repo parameter. This has occurred tens of thousands of times over the past couple weeks, and it is not clear to me how this alert is helping at this point.

## Was the documentation (API, README, DevOpsDocs, wiki, consul, etc.) updated?

no