### PR TITLE
validate druids to have the correct format and prefix before creating

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'activerecord-import' # we can remove this after we've migrated the data
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'config', '~> 1.7'
 gem 'dor-services-client', '~> 2.0'
+gem 'druid-tools'
 gem 'honeybadger', '~> 4.1'
 gem 'jbuilder', '~> 2.5'
 gem 'okcomputer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -342,6 +342,7 @@ DEPENDENCIES
   dlss-capistrano
   dor-services-client (~> 2.0)
   dor-workflow-service (~> 2.3)
+  druid-tools
   equivalent-xml
   factory_bot_rails
   honeybadger (~> 4.1)

--- a/app/models/workflow_step.rb
+++ b/app/models/workflow_step.rb
@@ -2,7 +2,7 @@
 
 # Models a process that occurred for a digital object. Basically a log entry.
 class WorkflowStep < ApplicationRecord
-  validates :druid, format: { with: /\Adruid:[a-zA-Z]{2}\d{3}[a-zA-Z]{2}\d{4}/, message: 'is invalid format or missing prefix' }
+  validate :druid_is_valid
   validates :workflow, presence: true
   validates :process, presence: true
   validates :version, numericality: { only_integer: true }
@@ -31,6 +31,13 @@ class WorkflowStep < ApplicationRecord
   end
 
   ##
+  # check if we have a valid druid with prefix
+  # @return [boolean]
+  def valid_druid?
+    DruidTools::Druid.valid?(druid, true) && druid.starts_with?('druid:')
+  end
+
+  ##
   # check if the named workflow has a current definition
   # @return [boolean]
   def valid_workflow?
@@ -45,6 +52,11 @@ class WorkflowStep < ApplicationRecord
 
     wtp = WorkflowTemplateParser.new(WorkflowTemplateLoader.new(workflow).load_as_xml)
     wtp.processes.map(&:name).include? process
+  end
+
+  # ensure we have a valid druid with prefix
+  def druid_is_valid
+    errors.add(:druid, 'is not valid') unless valid_druid?
   end
 
   # ensure we have a valid workflow before creating a new step

--- a/app/models/workflow_step.rb
+++ b/app/models/workflow_step.rb
@@ -2,7 +2,7 @@
 
 # Models a process that occurred for a digital object. Basically a log entry.
 class WorkflowStep < ApplicationRecord
-  validates :druid, presence: true
+  validates :druid, format: { with: /\Adruid:[a-zA-Z]{2}\d{3}[a-zA-Z]{2}\d{4}/, message: 'is invalid format or missing prefix' }
   validates :workflow, presence: true
   validates :process, presence: true
   validates :version, numericality: { only_integer: true }

--- a/spec/controllers/workflows_controller_spec.rb
+++ b/spec/controllers/workflows_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe WorkflowsController do
   end
 
   describe 'deprecated PUT create' do
-    let(:druid) { 'druid:ab123ab1234' }
+    let(:druid) { 'druid:bb123bb1234' }
     let(:workflow) { 'accessionWF' }
     let(:repository) { 'dor' }
     let(:request_data) { workflow_template }
@@ -77,7 +77,7 @@ RSpec.describe WorkflowsController do
   end
 
   describe 'POST create' do
-    let(:druid) { 'druid:ab123ab1234' }
+    let(:druid) { 'druid:bb123bb1234' }
     let(:workflow) { 'accessionWF' }
     let(:lane_id) { 'foo' }
 

--- a/spec/controllers/workflows_controller_spec.rb
+++ b/spec/controllers/workflows_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe WorkflowsController do
   end
 
   describe 'deprecated PUT create' do
-    let(:druid) { 'druid:abc123' }
+    let(:druid) { 'druid:ab123ab1234' }
     let(:workflow) { 'accessionWF' }
     let(:repository) { 'dor' }
     let(:request_data) { workflow_template }
@@ -77,7 +77,7 @@ RSpec.describe WorkflowsController do
   end
 
   describe 'POST create' do
-    let(:druid) { 'druid:abc123' }
+    let(:druid) { 'druid:ab123ab1234' }
     let(:workflow) { 'accessionWF' }
     let(:lane_id) { 'foo' }
 

--- a/spec/factories/workflow_steps.rb
+++ b/spec/factories/workflow_steps.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :workflow_step do
     sequence :druid do |n|
-      "druid:ab123bb#{n.to_s.rjust(4, '0')}" # ensure we always have a valid druid format
+      "druid:bb123bc#{n.to_s.rjust(4, '0')}" # ensure we always have a valid druid format
     end
     workflow { 'accessionWF' }
     process { 'start-accession' }

--- a/spec/factories/workflow_steps.rb
+++ b/spec/factories/workflow_steps.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :workflow_step do
     sequence :druid do |n|
-      "druid:abc123#{n}"
+      "druid:ab123bb#{n.to_s.rjust(4, '0')}" # ensure we always have a valid druid format
     end
     workflow { 'accessionWF' }
     process { 'start-accession' }

--- a/spec/models/workflow_step_spec.rb
+++ b/spec/models/workflow_step_spec.rb
@@ -20,6 +20,15 @@ RSpec.describe WorkflowStep do
     it { is_expected.not_to be_valid }
   end
 
+  context 'without valid druid' do
+    it 'is not valid if the druid is missing the prefix' do
+      expect { step.druid = step.druid.delete('druid:') }.to change { step.valid? }.from(true).to(false)
+    end
+    it 'is not valid if the druid is a bogus value' do
+      expect { step.druid = 'bogus' }.to change { step.valid? }.from(true).to(false)
+    end
+  end
+
   context 'without valid status' do
     it 'is not valid if the status is nil' do
       expect { step.status = nil }.to change { step.valid? }.from(true).to(false)

--- a/spec/requests/workflows/single_workflow_for_object_spec.rb
+++ b/spec/requests/workflows/single_workflow_for_object_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'Get a single workflow for an object', type: :request do
     end
 
     context 'when no workflow exists' do
-      let(:druid) { 'druid:ab123ab12342' }
+      let(:druid) { 'druid:bb123bb12342' }
 
       it 'returns an empy workflow node' do
         get "/objects/#{druid}/workflows/accessionWF"

--- a/spec/requests/workflows/single_workflow_for_object_spec.rb
+++ b/spec/requests/workflows/single_workflow_for_object_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'Get a single workflow for an object', type: :request do
     end
 
     context 'when no workflow exists' do
-      let(:druid) { 'druid:abc1232' }
+      let(:druid) { 'druid:ab123ab12342' }
 
       it 'returns an empy workflow node' do
         get "/objects/#{druid}/workflows/accessionWF"

--- a/spec/services/send_update_message_spec.rb
+++ b/spec/services/send_update_message_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe SendUpdateMessage do
-  let(:druid) { 'druid:ab123ab1234' }
+  let(:druid) { 'druid:bb123bb1234' }
 
   describe '#publish' do
     let(:sender) { described_class.new(druid: druid) }
@@ -23,7 +23,7 @@ RSpec.describe SendUpdateMessage do
       expect(mock_client).to have_received(:publish)
         .with('/topic/fedora.apim.update',
               'hello',
-              'methodName' => 'modifyObject', 'pid' => 'druid:ab123ab1234')
+              'methodName' => 'modifyObject', 'pid' => 'druid:bb123bb1234')
     end
   end
 
@@ -49,7 +49,7 @@ RSpec.describe SendUpdateMessage do
                   <uri>https://dor-test.stanford.edu</uri>
               </author>
               <title type="text">modifyObject</title>
-              <summary type="text">druid:ab123ab1234</summary>
+              <summary type="text">druid:bb123bb1234</summary>
               <content type="text">2019-01-25T15:18:32Z</content>
           </entry>
         XML

--- a/spec/services/send_update_message_spec.rb
+++ b/spec/services/send_update_message_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe SendUpdateMessage do
-  let(:druid) { 'druid:abc123' }
+  let(:druid) { 'druid:ab123ab1234' }
 
   describe '#publish' do
     let(:sender) { described_class.new(druid: druid) }
@@ -23,7 +23,7 @@ RSpec.describe SendUpdateMessage do
       expect(mock_client).to have_received(:publish)
         .with('/topic/fedora.apim.update',
               'hello',
-              'methodName' => 'modifyObject', 'pid' => 'druid:abc123')
+              'methodName' => 'modifyObject', 'pid' => 'druid:ab123ab1234')
     end
   end
 
@@ -49,7 +49,7 @@ RSpec.describe SendUpdateMessage do
                   <uri>https://dor-test.stanford.edu</uri>
               </author>
               <title type="text">modifyObject</title>
-              <summary type="text">druid:abc123</summary>
+              <summary type="text">druid:ab123ab1234</summary>
               <content type="text">2019-01-25T15:18:32Z</content>
           </entry>
         XML

--- a/spec/services/workflow_creator_spec.rb
+++ b/spec/services/workflow_creator_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe WorkflowCreator do
-  let(:druid) { 'druid:ab123ab1234' }
+  let(:druid) { 'druid:bb123bb1234' }
   let(:repository) { 'dor' }
   let(:xml) do
     workflow_template = WorkflowTemplateLoader.load_as_xml('accessionWF', 'dor')

--- a/spec/services/workflow_creator_spec.rb
+++ b/spec/services/workflow_creator_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe WorkflowCreator do
-  let(:druid) { 'druid:abc123' }
+  let(:druid) { 'druid:ab123ab1234' }
   let(:repository) { 'dor' }
   let(:xml) do
     workflow_template = WorkflowTemplateLoader.load_as_xml('accessionWF', 'dor')

--- a/spec/views/workflows/archive.xml.builder_spec.rb
+++ b/spec/views/workflows/archive.xml.builder_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'workflows/archive' do
-  let(:druid) { 'druid:abc123' }
+  let(:druid) { 'druid:ab123ab1234' }
   let(:repo) { 'dor' }
   let(:params) { { druid: druid, repo: repo } }
   it 'renders a workflows document' do

--- a/spec/views/workflows/archive.xml.builder_spec.rb
+++ b/spec/views/workflows/archive.xml.builder_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'workflows/archive' do
-  let(:druid) { 'druid:ab123ab1234' }
+  let(:druid) { 'druid:bb123bb1234' }
   let(:repo) { 'dor' }
   let(:params) { { druid: druid, repo: repo } }
   it 'renders a workflows document' do

--- a/spec/views/workflows/index.xml.builder_spec.rb
+++ b/spec/views/workflows/index.xml.builder_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'workflows/index' do
-  let(:druid) { 'druid:abc123' }
+  let(:druid) { 'druid:ab123ab1234' }
   let(:repo) { 'dor' }
 
   let(:step) do
@@ -32,10 +32,10 @@ RSpec.describe 'workflows/index' do
   it 'renders a workflows document' do
     render template: 'workflows/index', locals: { params: params }
     doc = Nokogiri::XML.parse(rendered)
-    expect(doc.at_xpath('//workflows')).to include %w[objectId druid:abc123]
+    expect(doc.at_xpath('//workflows')).to include %w[objectId druid:ab123ab1234]
     expect(doc.at_xpath('//workflow')).to include(
       %w[repository dor],
-      %w[objectId druid:abc123],
+      %w[objectId druid:ab123ab1234],
       %w[id accessionWF]
     )
     expect(doc.at_xpath('//process')).to include(

--- a/spec/views/workflows/index.xml.builder_spec.rb
+++ b/spec/views/workflows/index.xml.builder_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'workflows/index' do
-  let(:druid) { 'druid:ab123ab1234' }
+  let(:druid) { 'druid:bb123bb1234' }
   let(:repo) { 'dor' }
 
   let(:step) do
@@ -32,10 +32,10 @@ RSpec.describe 'workflows/index' do
   it 'renders a workflows document' do
     render template: 'workflows/index', locals: { params: params }
     doc = Nokogiri::XML.parse(rendered)
-    expect(doc.at_xpath('//workflows')).to include %w[objectId druid:ab123ab1234]
+    expect(doc.at_xpath('//workflows')).to include %w[objectId druid:bb123bb1234]
     expect(doc.at_xpath('//workflow')).to include(
       %w[repository dor],
-      %w[objectId druid:ab123ab1234],
+      %w[objectId druid:bb123bb1234],
       %w[id accessionWF]
     )
     expect(doc.at_xpath('//process')).to include(

--- a/spec/views/workflows/lifecycle.xml.builder_spec.rb
+++ b/spec/views/workflows/lifecycle.xml.builder_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'workflows/lifecycle' do
-  let(:druid) { 'druid:ab123ab1234' }
+  let(:druid) { 'druid:bb123bb1234' }
   let(:repo) { 'dor' }
   let(:params) { { druid: druid, repo: repo } }
 
@@ -18,7 +18,7 @@ RSpec.describe 'workflows/lifecycle' do
 
     render template: 'workflows/lifecycle', locals: { params: params }
     doc = Nokogiri::XML.parse(rendered)
-    expect(doc.at_xpath('//lifecycle')).to include %w[objectId druid:ab123ab1234]
+    expect(doc.at_xpath('//lifecycle')).to include %w[objectId druid:bb123bb1234]
     expect(doc.at_xpath('//milestone')).to include(
       ['version', /1/],
       ['date', //]

--- a/spec/views/workflows/lifecycle.xml.builder_spec.rb
+++ b/spec/views/workflows/lifecycle.xml.builder_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'workflows/lifecycle' do
-  let(:druid) { 'druid:abc123' }
+  let(:druid) { 'druid:ab123ab1234' }
   let(:repo) { 'dor' }
   let(:params) { { druid: druid, repo: repo } }
 
@@ -18,7 +18,7 @@ RSpec.describe 'workflows/lifecycle' do
 
     render template: 'workflows/lifecycle', locals: { params: params }
     doc = Nokogiri::XML.parse(rendered)
-    expect(doc.at_xpath('//lifecycle')).to include %w[objectId druid:abc123]
+    expect(doc.at_xpath('//lifecycle')).to include %w[objectId druid:ab123ab1234]
     expect(doc.at_xpath('//milestone')).to include(
       ['version', /1/],
       ['date', //]

--- a/spec/views/workflows/show.xml.builder_spec.rb
+++ b/spec/views/workflows/show.xml.builder_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'workflows/index' do
-  let(:druid) { 'druid:abc123' }
+  let(:druid) { 'druid:ab123ab1234' }
   let(:repo) { 'dor' }
 
   let(:step) do
@@ -25,7 +25,7 @@ RSpec.describe 'workflows/index' do
     doc = Nokogiri::XML.parse(rendered)
     expect(doc.at_xpath('//workflow')).to include(
       %w[repository dor],
-      %w[objectId druid:abc123],
+      %w[objectId druid:ab123ab1234],
       %w[id accessionWF]
     )
     expect(doc.at_xpath('//process')).to include(

--- a/spec/views/workflows/show.xml.builder_spec.rb
+++ b/spec/views/workflows/show.xml.builder_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'workflows/index' do
-  let(:druid) { 'druid:ab123ab1234' }
+  let(:druid) { 'druid:bb123bb1234' }
   let(:repo) { 'dor' }
 
   let(:step) do
@@ -25,7 +25,7 @@ RSpec.describe 'workflows/index' do
     doc = Nokogiri::XML.parse(rendered)
     expect(doc.at_xpath('//workflow')).to include(
       %w[repository dor],
-      %w[objectId druid:ab123ab1234],
+      %w[objectId druid:bb123bb1234],
       %w[id accessionWF]
     )
     expect(doc.at_xpath('//process')).to include(


### PR DESCRIPTION
## Why was this change made?

fixes #300 

Currently we have a bug in preservation_catalog where we are creating workflows without a druid prefix, and these results in workflows that aren't being picked up by indexing and shown in argo.  We should validate at this level to ensure this can't happen.

## Was the documentation (API, README, DevOpsDocs, wiki, consul, etc.) updated?
