### PR TITLE
remove unnecessary dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,6 @@ gem 'whenever', require: false
 
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
-  gem 'dor-workflow-service', '~> 2.3'
   gem 'equivalent-xml'
   gem 'factory_bot_rails'
   gem 'rails-controller-testing'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,6 @@ GEM
       dry-validation (~> 0.12, >= 0.12.2, < 1.0.0)
     confstruct (1.0.2)
       hashie (~> 3.3)
-    connection_pool (2.2.2)
     crass (1.0.5)
     deep_merge (1.2.1)
     deprecation (1.0.0)
@@ -105,14 +104,6 @@ GEM
       moab-versioning (~> 4.0)
       nokogiri (~> 1.8)
       zeitwerk (~> 2.1)
-    dor-workflow-service (2.12.0)
-      activesupport (>= 3.2.1, < 6)
-      confstruct (>= 0.2.7, < 2)
-      deprecation
-      faraday (~> 0.9, >= 0.9.2)
-      net-http-persistent (>= 2.9.4, < 4.a)
-      nokogiri (~> 1.6)
-      retries
     druid-tools (2.1.0)
       deprecation
     dry-configurable (0.9.0)
@@ -197,8 +188,6 @@ GEM
     multi_json (1.14.1)
     multipart-post (2.1.1)
     mustermann (1.0.3)
-    net-http-persistent (3.1.0)
-      connection_pool (~> 2.2)
     net-scp (2.0.0)
       net-ssh (>= 2.6.5, < 6.0.0)
     net-ssh (5.2.0)
@@ -260,7 +249,6 @@ GEM
       redis-namespace (~> 1.6)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
-    retries (0.0.5)
     rspec-core (3.9.0)
       rspec-support (~> 3.9.0)
     rspec-expectations (3.9.0)
@@ -341,7 +329,6 @@ DEPENDENCIES
   config (~> 1.7)
   dlss-capistrano
   dor-services-client (~> 2.0)
-  dor-workflow-service (~> 2.3)
   druid-tools
   equivalent-xml
   factory_bot_rails


### PR DESCRIPTION
## Why was this change made?
This prevents upgrading to rails 6

## Was the documentation (API, README, DevOpsDocs, wiki, consul, etc.) updated?
n/a