### PR TITLE
Use rails 6 defaults

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,7 @@ module WorkflowServer
   # Base Application
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.2
+    config.load_defaults 6.0
 
     # Log to STDOUT
     unless Rails.env.test?


### PR DESCRIPTION
## Why was this change made?

To be consistent with a rails 6.0 project

## Was the documentation (API, README, DevOpsDocs, wiki, consul, etc.) updated?
n/a