### PR TITLE
Install the right version of bundler in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN apk --no-cache add \
   postgresql-client \
   tzdata
 
+RUN gem install bundler:2.1.1
+
 RUN mkdir /app
 WORKDIR /app
 


### PR DESCRIPTION
## Why was this change made?

Currently the build docker image fails because it doesn't have the correct version of bundler installed.

## Was the documentation (API, README, DevOpsDocs, wiki, consul, etc.) updated?
n/a