### PR TITLE
Install bundler 2.1 in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,8 @@
 .git
 .dockerignore
 .byebug_history
-log/*
-tmp/*
+
+log
+tmp
+# Required for puma to have a place to put the pid file
+!tmp/pids/.keep

--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,12 @@
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*
+/tmp/pids/*
 !/log/.keep
 !/tmp/.keep
+!/tmp/pids
+# Required for puma to have a place to put the pid file
+!/tmp/pids/.keep
 
 /spec/examples.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ RUN apk --no-cache add \
   postgresql-client \
   tzdata
 
+# Get bundler 2.1
+RUN gem install bundler
+
 RUN mkdir /app
 WORKDIR /app
 

--- a/docker/invoke.sh
+++ b/docker/invoke.sh
@@ -15,12 +15,12 @@ echo "Postgres is up - Setting up database"
 set +e
 echo "Creating DB. OK to ignore errors about test db."
 # https://github.com/rails/rails/issues/27299
-rails db:create
+./bin/rails db:create
 
 # Don't allow any following commands to fail
 set -e
 echo "Migrating db"
-rails db:migrate
+./bin/rails db:migrate
 
 echo "Running server"
-exec puma -C config/puma.rb config.ru
+exec bundle exec puma -C config/puma.rb config.ru


### PR DESCRIPTION
also create a place for the pidfile to go in the docker image

## Why was this change made?

Previously it was unable to start the docker image (after Rails 6 upgrade) because the puma config had changed.

## Was the documentation (API, README, DevOpsDocs, wiki, consul, etc.) updated?
n/a