### PR TITLE
Allow closing a version without providing a repository

### DIFF
--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -29,7 +29,7 @@ class VersionsController < ApplicationController
   end
 
   def initialize_workflow
-    obj = Version.new(repository: params[:repo],
+    obj = Version.new(repository: 'dor',
                       druid: params[:druid],
                       version: current_version)
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,8 @@ Rails.application.routes.draw do
 
   scope 'objects/:druid', constraints: { druid: %r{[^\/]+} }, defaults: { format: :xml } do
     delete 'workflows', to: 'steps#destroy_all'
+    post 'versionClose', to: 'versions#close'
+
     resources :workflows, only: %i[show index], param: :workflow do
       collection do
         post ':workflow', to: 'workflows#create'

--- a/spec/requests/version_close_spec.rb
+++ b/spec/requests/version_close_spec.rb
@@ -12,8 +12,16 @@ RSpec.describe 'Close a version', type: :request do
     allow(QueueService).to receive(:enqueue)
   end
 
+  context 'deprecated route' do
+    it 'closes the version' do
+      post "/dor/objects/#{druid}/versionClose"
+      expect(response).to be_successful
+      expect(WorkflowStep.where(druid: druid).count).to eq 16
+    end
+  end
+
   it 'closes the version' do
-    post "/dor/objects/#{druid}/versionClose"
+    post "/objects/#{druid}/versionClose"
     expect(response).to be_successful
     expect(WorkflowStep.where(druid: druid).count).to eq 16
   end


### PR DESCRIPTION
## Why was this change made?

This is only ever used by dor-services-app and the repository is always 'dor'


## Was the documentation (API, README, DevOpsDocs, wiki, consul, etc.) updated?
n/a