### PR TITLE
Run CI tests on master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,6 +138,10 @@ jobs:
 workflows:
   version: 2
 
+  test:
+    jobs:
+    - test
+
   build:
     jobs:
     - build-image:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,13 +138,6 @@ jobs:
 workflows:
   version: 2
 
-  test:
-    jobs:
-    - test:
-        filters:
-          branches:
-            ignore: master
-
   build:
     jobs:
     - build-image:


### PR DESCRIPTION
This was disabled in the CircleCI config, likely because of copypasta.
