### PR TITLE
Notify honeybadger when a version is not provided

### DIFF
--- a/app/services/object_version_service.rb
+++ b/app/services/object_version_service.rb
@@ -12,6 +12,10 @@ class ObjectVersionService
   end
 
   def current_version(druid)
+    # raise
+    Honeybadger.notify('[WARN] Deprecated call to ObjectVersionService.  ' \
+      'This happens when a version was not passed to the workflow service.  ' \
+      'We would like to elimnate any call that requires a version and does not provide one.')
     client.object(druid).version.current
   rescue Dor::Services::Client::NotFoundResponse # A 404 error
     1

--- a/spec/requests/lifecycle_spec.rb
+++ b/spec/requests/lifecycle_spec.rb
@@ -39,9 +39,19 @@ RSpec.describe 'Lifecycle', type: :request do
         allow(Dor::Services::Client).to receive(:object).with(druid).and_return(client)
       end
 
-      it 'draws an empty set of milestones' do
-        get "/dor/objects/#{druid}/lifecycle?active-only=true"
-        expect(returned_milestone_versions).to eq []
+      context 'when version is not passed (deprecated)' do
+        it 'draws an empty set of milestones and notifies honeybadger' do
+          expect(Honeybadger).to receive(:notify)
+          get "/dor/objects/#{druid}/lifecycle?active-only=true"
+          expect(returned_milestone_versions).to eq []
+        end
+      end
+
+      context 'when version is passed' do
+        it 'draws an empty set of milestones' do
+          get "/dor/objects/#{druid}/lifecycle?active-only=true&version=2"
+          expect(returned_milestone_versions).to eq []
+        end
       end
     end
 
@@ -63,10 +73,22 @@ RSpec.describe 'Lifecycle', type: :request do
         allow(Dor::Services::Client).to receive(:object).with(druid).and_return(client)
       end
 
-      it 'draws milestones from the current version' do
-        get "/dor/objects/#{druid}/lifecycle?active-only=true"
-        expect(returned_milestone_versions).to eq ['2']
-        expect(returned_milestone_text).to eq ['submitted']
+      context 'when version is not passed (deprecated)' do
+        it 'draws milestones from the current version and notifies honeybadger' do
+          expect(Honeybadger).to receive(:notify)
+
+          get "/dor/objects/#{druid}/lifecycle?active-only=true"
+          expect(returned_milestone_versions).to eq ['2']
+          expect(returned_milestone_text).to eq ['submitted']
+        end
+      end
+
+      context 'when version is passed' do
+        it 'draws milestones from the current version' do
+          get "/dor/objects/#{druid}/lifecycle?active-only=true&version=2"
+          expect(returned_milestone_versions).to eq ['2']
+          expect(returned_milestone_text).to eq ['submitted']
+        end
       end
     end
   end

--- a/spec/requests/version_close_spec.rb
+++ b/spec/requests/version_close_spec.rb
@@ -4,25 +4,41 @@ require 'rails_helper'
 
 RSpec.describe 'Close a version', type: :request do
   let(:druid) { FactoryBot.build(:workflow_step).druid }
-  let(:object_client) { instance_double(Dor::Services::Client::Object, version: version_client) }
-  let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, current: '2') }
 
   before do
-    allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)
     allow(QueueService).to receive(:enqueue)
   end
 
-  context 'deprecated route' do
+  context 'when version is not passed (deprecated)' do
+    let(:object_client) { instance_double(Dor::Services::Client::Object, version: version_client) }
+    let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, current: '2') }
+
+    before do
+      allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)
+    end
+
+    context 'with repository route (deprecated)' do
+      it 'closes the version and notifies honeybadger' do
+        expect(Honeybadger).to receive(:notify)
+
+        post "/dor/objects/#{druid}/versionClose"
+        expect(response).to be_successful
+        expect(WorkflowStep.where(druid: druid).count).to eq 16
+      end
+    end
+
     it 'closes the version' do
-      post "/dor/objects/#{druid}/versionClose"
+      post "/objects/#{druid}/versionClose"
       expect(response).to be_successful
       expect(WorkflowStep.where(druid: druid).count).to eq 16
     end
   end
 
-  it 'closes the version' do
-    post "/objects/#{druid}/versionClose"
-    expect(response).to be_successful
-    expect(WorkflowStep.where(druid: druid).count).to eq 16
+  context 'when version is passed' do
+    it 'closes the version' do
+      post "/objects/#{druid}/versionClose?version=3"
+      expect(response).to be_successful
+      expect(WorkflowStep.where(druid: druid).count).to eq 16
+    end
   end
 end

--- a/spec/requests/workflows/destroy_workflow_spec.rb
+++ b/spec/requests/workflows/destroy_workflow_spec.rb
@@ -3,17 +3,29 @@
 require 'rails_helper'
 
 RSpec.describe 'Destroy a workflow' do
-  let(:client) { instance_double(Dor::Services::Client::Object, version: version_client) }
-  let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, current: '1') }
   let(:wf) { FactoryBot.create(:workflow_step) }
   let(:druid) { wf.druid }
 
-  before do
-    allow(Dor::Services::Client).to receive(:object).with(druid).and_return(client)
+  context 'when version is not passed (deprecated)' do
+    let(:client) { instance_double(Dor::Services::Client::Object, version: version_client) }
+    let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, current: '1') }
+
+    before do
+      allow(Dor::Services::Client).to receive(:object).with(druid).and_return(client)
+    end
+
+    it 'deletes workflows and notifies honeybadger' do
+      expect(Honeybadger).to receive(:notify)
+
+      delete "/dor/objects/#{druid}/workflows/#{wf.workflow}"
+      expect(response).to be_no_content
+    end
   end
 
-  it 'deletes workflows' do
-    delete "/dor/objects/#{druid}/workflows/#{wf.workflow}"
-    expect(response).to be_no_content
+  context 'when version is passed' do
+    it 'deletes workflows' do
+      delete "/dor/objects/#{druid}/workflows/#{wf.workflow}?version=1"
+      expect(response).to be_no_content
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made?

We don't want the workflow service to call back to dor-services-app to get the version. The consumer should be providing it.  This allows us to identify consumers that are using the old behavior

## Was the documentation (API, README, DevOpsDocs, wiki, consul, etc.) updated?
n/a