### PR TITLE
Raises error if enqueue_to returns false.

### DIFF
--- a/app/services/queue_service.rb
+++ b/app/services/queue_service.rb
@@ -17,7 +17,10 @@ class QueueService
 
   # Enqueue the provided step
   def enqueue
-    Resque.enqueue_to(queue_name, class_name, step.druid)
+    # .enqueue_to will return false if a pre-queue hook prevented it from queueing.
+    # Don't necessarily expect this to occur, but want to prevent from failing silently.
+    raise "Enqueueing #{class_name} for #{step.druid} to #{queue_name} failed." unless Resque.enqueue_to(queue_name, class_name, step.druid)
+
     Rails.logger.info "Enqueued #{class_name} for #{step.druid} to #{queue_name}"
 
     # Update status

--- a/spec/services/queue_service_spec.rb
+++ b/spec/services/queue_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe QueueService do
 
   describe '#enqueue' do
     before do
-      allow(Resque).to receive(:enqueue_to)
+      allow(Resque).to receive(:enqueue_to).and_return(true)
     end
 
     context 'for JP2 robot (special case)' do
@@ -42,6 +42,18 @@ RSpec.describe QueueService do
         expect(Resque).to have_received(:enqueue_to).with('preservationIngestWF_default',
                                                           'Robots::SdrRepo::PreservationIngest::TransferObject', step.druid)
         expect(step.status).to eq('queued')
+      end
+    end
+
+    context 'when .enqueue_to returns false' do
+      before do
+        allow(Resque).to receive(:enqueue_to).and_return(false)
+      end
+
+      let(:step) { FactoryBot.create(:workflow_step, workflow: 'assemblyWF', process: 'jp2-create') }
+
+      it 'raises' do
+        expect { service.enqueue }.to raise_error(/Enqueueing/)
       end
     end
   end


### PR DESCRIPTION
closes #330

## Why was this change made?
To prevent enqueueing from silently failing.

## Was the documentation (API, README, DevOpsDocs, wiki, consul, etc.) updated?
No.