### PR TITLE
Changes sweeper to ignore workflow steps that are not current version.

### DIFF
--- a/app/services/sweeper.rb
+++ b/app/services/sweeper.rb
@@ -20,6 +20,7 @@ class Sweeper
   def steps_to_sweep
     WorkflowStep.queued
                 .where(WorkflowStep.arel_table[:updated_at].lt(12.hours.ago))
+                .where(active_version: true)
                 .limit(1000)
   end
 

--- a/spec/services/sweeper_spec.rb
+++ b/spec/services/sweeper_spec.rb
@@ -21,16 +21,25 @@ RSpec.describe Sweeper do
     let(:stale) do
       FactoryBot.create(:workflow_step,
                         process: 'start-accession',
-                        version: 1,
+                        version: 2,
                         status: 'queued',
                         active_version: true,
+                        updated_at: 2.days.ago)
+    end
+    let!(:stale_version) do
+      FactoryBot.create(:workflow_step,
+                        druid: stale.druid,
+                        process: 'start-accession',
+                        version: 1,
+                        status: 'queued',
+                        active_version: false,
                         updated_at: 2.days.ago)
     end
     let!(:on_deck) do
       FactoryBot.create(:workflow_step,
                         druid: stale.druid,
                         process: 'descriptive-metadata',
-                        version: 1,
+                        version: 2,
                         status: 'waiting',
                         active_version: true)
     end


### PR DESCRIPTION
closes #335

## Why was this change made?
To avoid the sweeping cycle described in #335.

## Was the documentation (API, README, DevOpsDocs, wiki, consul, etc.) updated?
No.