### PR TITLE
deploy.rb: don't lock to Cap version

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # config valid for current version and patch releases of Capistrano
-lock '~> 3.11.0'
+# lock '~> 3.11.0'
 
 set :application, 'workflow-server-rails'
 set :repo_url, 'https://github.com/sul-dlss-labs/workflow-server-rails.git'


### PR DESCRIPTION
## Why was this change made?

To avoid this:

```sh
$ bx cap stage deploy
cap aborted!
Capfile locked at ~> 3.11.0, but 3.12.0 is loaded
```

very few of our projects have capistrano version selected:

```sh
ndushay@m3dl-sm-03-mbph-2 workflow-server-rails (unlock-cap) $ ack lock ../*/config/deploy.rb
../dlme-harvest/config/deploy.rb
4:lock '~> 3.11.0'

../robot-console/config/deploy.rb
2:# lock '~> 3.12.0'

../searchworks/config/deploy.rb
2:lock '3.4.0'

../sul_styles/config/deploy.rb
2:lock '3.4.0'

../workflow-server-rails/config/deploy.rb
4:# lock '~> 3.11.0'
```

## Was the documentation (API, README, DevOpsDocs, wiki, consul, etc.) updated?

na