### PR TITLE
Write and use OpenAPI specification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,20 @@ jobs:
         name: Check styles using rubocop
         command: bundle exec rubocop
 
+    - run:
+        name: Validate API specification
+        command: |
+          sudo npm install -g openapi-enforcer-cli
+          result=$(openapi-enforcer validate openapi.yml)
+          [[ $result =~ "Document is valid" ]] && {
+          echo "API specification is valid OAS (but may have warnings, see below)"
+          echo $result
+          exit 0
+          } || {
+          echo $result
+          exit 1
+          }
+
     # Run rspec in parallel
     - run:
         name: Run rspec in parallel

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gem 'rails', '~> 6.0.2'
 
 gem 'bootsnap', '>= 1.1.0', require: false
+gem 'committee' # Validates HTTP requests/responses per OpenAPI specification
 gem 'config', '~> 2.0'
 gem 'druid-tools'
 gem 'honeybadger', '~> 4.1'

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Test Coverage](https://api.codeclimate.com/v1/badges/cc78d20264a4eaf8a782/test_coverage)](https://codeclimate.com/github/sul-dlss/workflow-server-rails/test_coverage)
 [![Maintainability](https://api.codeclimate.com/v1/badges/cc78d20264a4eaf8a782/maintainability)](https://codeclimate.com/github/sul-dlss/workflow-server-rails/maintainability)
 [![](https://images.microbadger.com/badges/image/suldlss/workflow-server.svg)](https://microbadger.com/images/suldlss/workflow-server "Get your own image badge on microbadger.com")
+[![OpenAPI Validator](http://validator.swagger.io/validator?url=https://raw.githubusercontent.com/sul-dlss/workflow-server-rails/master/openapi.yml)](http://validator.swagger.io/validator/debug?url=https://raw.githubusercontent.com/sul-dlss/workflow-server-rails/master/openapi.yml)
 
 This is a Rails-based workflow service that replaced SDR's Java-based workflow service.  It is consumed by the users of dor-workflow-client (argo, hydrus, hydra_etd, pre-assembly, dor-indexing-app, robots) and *soon* the goobi application (currently proxying through dor-services-app).
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -58,7 +58,7 @@ module WorkflowServer
                                                                     strict: true, error_class: JSONAPIError,
                                                                     accept_request_filter: accept_proc
     # TODO: we can uncomment this at a later date to ensure we are passing back
-    #       valid responses. 
+    #       valid responses.
     #
     # config.middleware.use Committee::Middleware::ResponseValidation, schema_path: 'openapi.yml'
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -52,7 +52,6 @@ module WorkflowServer
       config.logger    = ActiveSupport::TaggedLogging.new(logger)
     end
 
-    # accept_request_filter omits OKComputer & Resque routes
     accept_proc = proc { |request| request.path.start_with?('/') }
     config.middleware.use Committee::Middleware::RequestValidation, schema_path: 'openapi.yml',
                                                                     strict: true, error_class: JSONAPIError,

--- a/config/application.rb
+++ b/config/application.rb
@@ -58,8 +58,7 @@ module WorkflowServer
                                                                     strict: true, error_class: JSONAPIError,
                                                                     accept_request_filter: accept_proc
     # TODO: we can uncomment this at a later date to ensure we are passing back
-    #       valid responses. Currently, uncommenting this line causes 24 spec
-    #       failures. See https://github.com/sul-dlss/preservation_catalog/issues/1407
+    #       valid responses. 
     #
     # config.middleware.use Committee::Middleware::ResponseValidation, schema_path: 'openapi.yml'
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,7 @@ require 'action_controller/railtie'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+# JSONAPIError class for returning properly formatted errors in openapi
 class JSONAPIError < Committee::ValidationError
   def error_body
     {
@@ -61,7 +62,6 @@ module WorkflowServer
     #       failures. See https://github.com/sul-dlss/preservation_catalog/issues/1407
     #
     # config.middleware.use Committee::Middleware::ResponseValidation, schema_path: 'openapi.yml'
-
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Workflow Server API documentation</title>
+
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <redoc spec-url='https://raw.githubusercontent.com/sul-dlss/workflow_server-rails/master/openapi.yml'></redoc>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-alpha.17/bundles/redoc.standalone.js"> </script>
+  </body>
+</html>

--- a/openapi.yml
+++ b/openapi.yml
@@ -7,17 +7,27 @@ info:
     name: Apache 2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
 servers:
-  - url: 'https://workflow-service-prod.stanford.edu'
+  - url: 'https://workflow-service-{env}.stanford.edu'
     description: Production service
     variables:
       env:
         default: prod
-  - url: 'https://workflow-service-stage.stanford.edu'
+  - url: 'https://workflow-service-{env}.stanford.edu'
     description: Staging service
     variables:
       env:
         default: stage
 paths:
+  /status:
+    get:
+      summary: OKComputer route for status checks
+      responses:
+        '200':
+          description: Response succeeded
+          content:
+            text/plain:
+              schema:
+                type: string
   /{repo}/objects/{druid}/lifecycle:
     get:
       summary: Retrieve workflow lifecycle for an object

--- a/openapi.yml
+++ b/openapi.yml
@@ -18,7 +18,7 @@ servers:
       env:
         default: stage
 paths:
-  /{repo}/objects/{druid}/lifecycle: # get - https://workflow-service-stage.stanford.edu/dor/objects/druid:nr660vn1106/lifecycle
+  /{repo}/objects/{druid}/lifecycle:
     get:
       summary: Retrieve workflow lifecycle for an object
       responses:
@@ -46,7 +46,7 @@ paths:
           required: false
           schema:
             type: boolean
-  /{repo}/objects/{druid}/versionClose: # post - DO NOT SEE THIS ONE IN THE LOGS
+  /{repo}/objects/{druid}/versionClose:
     post:
       summary: TODO
       responses:
@@ -72,10 +72,10 @@ paths:
             type: boolean
         - name: version
           in: query
-          required: true
+          required: false
           schema:
             type: integer 
-  /{repo}/objects/{druid}/workflows: # get - //dor/objects/druid:qr379tv2596/workflows
+  /{repo}/objects/{druid}/workflows:
     get:
       summary: Retrieve workflow datastream for an object
       responses:
@@ -116,7 +116,35 @@ paths:
           example: druid:bc123df4567
           schema:
             $ref: '#/components/schemas/Druid'
-  /{repo}/objects/{druid}/workflows/{workflow}: # put - DO NOT SEE THIS IN THE LOGS
+  /{repo}/objects/{druid}/workflows/{workflow}:
+    get:
+      summary: Show the named workflow for a given druid
+      responses:
+        '200':
+          description: List of workflow steps
+          content:
+            application/xml:
+              schema:
+                type: string
+      parameters:
+        - name: repo
+          in: path
+          required: true
+          example: dor
+          schema:
+            $ref: '#/components/schemas/Repository'
+        - name: druid
+          in: path
+          required: true
+          example: druid:bc123df4567
+          schema:
+            $ref: '#/components/schemas/Druid'
+        - name: workflow
+          in: path
+          required: true
+          example: accessionWF
+          schema:
+            $ref: '#/components/schemas/Workflow'  
     put:
       summary: Add provided workflow to object
       responses:
@@ -140,8 +168,32 @@ paths:
           required: true
           example: accessionWF
           schema:
-            $ref: '#/components/schemas/Workflow'  
-  /{repo}/objects/{druid}/workflows/{workflow}/{process}: # put | get - DO NOT SEE THIS ONE IN THE LOGS
+            $ref: '#/components/schemas/Workflow'
+    delete:
+      summary: Delete the workflow from the object
+      responses:
+        '200':
+          description: Request succeeded
+      parameters:
+        - name: repo
+          in: path
+          required: true
+          example: dor
+          schema:
+            $ref: '#/components/schemas/Repository'
+        - name: druid
+          in: path
+          required: true
+          example: druid:bc123df4567
+          schema:
+            $ref: '#/components/schemas/Druid'
+        - name: workflow
+          in: path
+          required: true
+          example: accessionWF
+          schema:
+            $ref: '#/components/schemas/Workflow'
+  /{repo}/objects/{druid}/workflows/{workflow}/{process}:
     get:
       summary: TODO
       responses:
@@ -206,7 +258,7 @@ paths:
           example: publish
           schema:
             $ref: '#/components/schemas/Process'
-  /objects/{druid}/workflows: # get | delete - //objects/druid:nw213cx6035/workflows 
+  /objects/{druid}/workflows:
     get:
       summary: Retrieve workflow datastream for an object
       responses:
@@ -235,7 +287,7 @@ paths:
           example: druid:bc123df4567
           schema:
             $ref: '#/components/schemas/Druid'
-  /objects/{druid}/versionClose: # post - //objects/druid:vy293gd2473/versionClose?create-accession=false&version=16
+  /objects/{druid}/versionClose:
     post:
       summary: TODO
       responses:
@@ -255,10 +307,32 @@ paths:
             type: boolean
         - name: version
           in: query
-          required: true
+          required: false
           schema:
             type: integer 
-  /objects/{druid}/workflows/{workflow}: # post - //objects/druid:qr023rk8145/workflows/registrationWF?lane-id=default&version=1
+  /objects/{druid}/workflows/{workflow}:
+    get:
+      summary: Show the named workflow for a given druid
+      responses:
+        '200':
+          description: List of workflow steps
+          content:
+            application/xml:
+              schema:
+                type: string
+      parameters:
+        - name: druid
+          in: path
+          required: true
+          example: druid:bc123df4567
+          schema:
+            $ref: '#/components/schemas/Druid'
+        - name: workflow
+          in: path
+          required: true
+          example: accessionWF
+          schema:
+            $ref: '#/components/schemas/Workflow'  
     post:
       summary: Add provided workflow to object
       responses:
@@ -277,7 +351,7 @@ paths:
           example: accessionWF
           schema:
             $ref: '#/components/schemas/Workflow'  
-  /objects/{druid}/workflows/{workflow}/{process}: # put - //objects/druid:vy293gd2473/workflows/assemblyWF/content-metadata-create
+  /objects/{druid}/workflows/{workflow}/{process}:
     put:
       summary: TODO
       responses:
@@ -302,7 +376,17 @@ paths:
           example: publish
           schema:
             $ref: '#/components/schemas/Process'
-  /workflow_templates/{workflow}: # get - //workflow_templates/registrationWF
+  /workflow_templates:
+    get:
+      summary: Retrieve workflow template for given workflow
+      responses:
+        '200':
+          description: Workflow datastreams found
+          content:
+            application/json:
+              schema:
+                type: string
+  /workflow_templates/{workflow}:
     get:
       summary: Retrieve workflow template for given workflow
       responses:
@@ -319,7 +403,7 @@ paths:
           example: accessionWF
           schema:
             $ref: '#/components/schemas/Workflow'
-  /workflow_archive: # get - DOES NOT LOOK USED
+  /workflow_archive:
     get:
       summary: TODO
       responses:
@@ -336,7 +420,7 @@ paths:
           example: accessionWF
           schema:
             $ref: '#/components/schemas/Workflow'
-  /workflow_queue: # get - //workflow_queue?completed=dor%3AetdSubmitWF%3Asubmit-marc&lane-id=default&waiting=dor%3AetdSubmitWF%3Acheck-marc
+  /workflow_queue:
     get:
       summary: TODO
       responses:
@@ -349,7 +433,7 @@ paths:
       parameters:
         - name: completed
           in: query
-          required: true
+          required: false
           example: dor:etdSubmitWF:catalog-status
           schema:
             type: string
@@ -359,7 +443,7 @@ paths:
           example: dor:etdSubmitWF:catalog-status
           schema:
             type: string
-  /workflow_queue/lane_ids: # get - //workflow_queue/lane_ids?step=dor%3AetdSubmitWF%3Acheck-marc (dor:etdSubmit:check-marc)
+  /workflow_queue/lane_ids:
     get:
       summary: TODO
       responses:
@@ -376,7 +460,7 @@ paths:
           example: dor:etdSubmitWF:catalog-status
           schema:
             type: string
-  /workflow_queue/all_queued: # get - DO NOT SEE IN LOGS
+  /workflow_queue/all_queued:
     get:
       summary: TODO
       responses:
@@ -403,11 +487,11 @@ components:
     Process:
       description: Process name
       type: string
-      enum: [accessioning-initiate, approve, check-marc, checksum-compute, complete-ingest, content-metadata,
-              content-metadata-create, descriptive-metadata, end-accession, exif-collect, jp2-create, preservation-ingest-initiated,
-              provenance-metadata, publish, publish-complete, reader-approval, registrar-approval, remediate-object,
-              reset-workspace, rights-metadata, sdr-ingest-received, sdr-ingest-transfer, shelve, shelve-complete,
-              start-assembly, submit, technical-metadata, transfer-object, update-catalog, update-moab, validate-bag, verify-apo]
+      enum: [start-accession, accessioning-initiate, approve, check-marc, checksum-compute, complete-ingest, content-metadata,
+             content-metadata-create, descriptive-metadata, end-accession, exif-collect, jp2-create, preservation-ingest-initiated,
+             provenance-metadata, publish, publish-complete, reader-approval, registrar-approval, remediate-object,
+             reset-workspace, rights-metadata, sdr-ingest-received, sdr-ingest-transfer, shelve, shelve-complete,
+             start-assembly, submit, technical-metadata, transfer-object, update-catalog, update-moab, validate-bag, verify-apo]
     Repository:
       description: Repository Identifier
       type: string

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,0 +1,422 @@
+openapi: 3.0.0
+info:
+  description: Workflow Server HTTP API
+  version: 1.0.0
+  title: Workflow Server HTTP API
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+servers:
+  - url: 'https://workflow-service-prod.stanford.edu'
+    description: Production service
+    variables:
+      env:
+        default: prod
+  - url: 'https://workflow-service-stage.stanford.edu'
+    description: Staging service
+    variables:
+      env:
+        default: stage
+paths:
+  /{repo}/objects/{druid}/lifecycle: # get - https://workflow-service-stage.stanford.edu/dor/objects/druid:nr660vn1106/lifecycle
+    get:
+      summary: Retrieve workflow lifecycle for an object
+      responses:
+        '200':
+          description: Workflow lifecycle found
+          content:
+            application/xml:
+              schema:
+                type: string
+      parameters:
+        - name: repo
+          in: path
+          required: true
+          example: dor
+          schema:
+            $ref: '#/components/schemas/Repository'
+        - name: druid
+          in: path
+          required: true
+          example: druid:bc123df4567
+          schema:
+            $ref: '#/components/schemas/Druid'
+        - name: active-only
+          in: query
+          required: false
+          schema:
+            type: boolean
+  /{repo}/objects/{druid}/versionClose: # post - DO NOT SEE THIS ONE IN THE LOGS
+    post:
+      summary: TODO
+      responses:
+        '200':
+          description: Request succeeded
+      parameters:
+        - name: repo
+          in: path
+          required: true
+          example: dor
+          schema:
+            $ref: '#/components/schemas/Repository'
+        - name: druid
+          in: path
+          required: true
+          example: druid:bc123df4567
+          schema:
+            $ref: '#/components/schemas/Druid'
+        - name: create-accession
+          in: query
+          required: false
+          schema:
+            type: boolean
+        - name: version
+          in: query
+          required: true
+          schema:
+            type: integer 
+  /{repo}/objects/{druid}/workflows: # get - //dor/objects/druid:qr379tv2596/workflows
+    get:
+      summary: Retrieve workflow datastream for an object
+      responses:
+        '200':
+          description: Workflow datastream found
+          content:
+            application/xml:
+              schema:
+                type: string
+      parameters:
+        - name: repo
+          in: path
+          required: true
+          example: dor
+          schema:
+            $ref: '#/components/schemas/Repository'
+        - name: druid
+          in: path
+          required: true
+          example: druid:bc123df4567
+          schema:
+            $ref: '#/components/schemas/Druid'
+    delete:
+      summary: Delete all of the workflows for an object
+      responses:
+        '204':
+          description: No Content
+      parameters:
+        - name: repo
+          in: path
+          required: true
+          example: dor
+          schema:
+            $ref: '#/components/schemas/Repository'
+        - name: druid
+          in: path
+          required: true
+          example: druid:bc123df4567
+          schema:
+            $ref: '#/components/schemas/Druid'
+  /{repo}/objects/{druid}/workflows/{workflow}: # put - DO NOT SEE THIS IN THE LOGS
+    put:
+      summary: Add provided workflow to object
+      responses:
+        '200':
+          description: Request succeeded
+      parameters:
+        - name: repo
+          in: path
+          required: true
+          example: dor
+          schema:
+            $ref: '#/components/schemas/Repository'
+        - name: druid
+          in: path
+          required: true
+          example: druid:bc123df4567
+          schema:
+            $ref: '#/components/schemas/Druid'
+        - name: workflow
+          in: path
+          required: true
+          example: accessionWF
+          schema:
+            $ref: '#/components/schemas/Workflow'  
+  /{repo}/objects/{druid}/workflows/{workflow}/{process}: # put | get - DO NOT SEE THIS ONE IN THE LOGS
+    get:
+      summary: TODO
+      responses:
+        '200':
+          description: List of process steps
+          content:
+            application/xml:
+              schema:
+                type: string
+      parameters:
+        - name: repo
+          in: path
+          required: true
+          example: dor
+          schema:
+            $ref: '#/components/schemas/Repository'
+        - name: druid
+          in: path
+          required: true
+          example: druid:bc123df4567
+          schema:
+            $ref: '#/components/schemas/Druid'
+        - name: workflow
+          in: path
+          required: true
+          example: accessionWF
+          schema:
+            $ref: '#/components/schemas/Workflow'  
+        - name: process
+          in: path
+          required: true
+          example: publish
+          schema:
+            $ref: '#/components/schemas/Process'          
+    put:
+      summary: TODO
+      responses:
+        '200':
+          description: Request succeeded
+      parameters:
+        - name: repo
+          in: path
+          required: true
+          example: dor
+          schema:
+            $ref: '#/components/schemas/Repository'
+        - name: druid
+          in: path
+          required: true
+          example: druid:bc123df4567
+          schema:
+            $ref: '#/components/schemas/Druid'
+        - name: workflow
+          in: path
+          required: true
+          example: accessionWF
+          schema:
+            $ref: '#/components/schemas/Workflow'  
+        - name: process
+          in: path
+          required: true
+          example: publish
+          schema:
+            $ref: '#/components/schemas/Process'
+  /objects/{druid}/workflows: # get | delete - //objects/druid:nw213cx6035/workflows 
+    get:
+      summary: Retrieve workflow datastream for an object
+      responses:
+        '200':
+          description: Workflow datastream found
+          content:
+            application/xml:
+              schema:
+                type: string
+      parameters:
+        - name: druid
+          in: path
+          required: true
+          example: druid:bc123df4567
+          schema:
+            $ref: '#/components/schemas/Druid'
+    delete:
+      summary: Delete all of the workflows for an object
+      responses:
+        '204':
+          description: No Content
+      parameters:
+        - name: druid
+          in: path
+          required: true
+          example: druid:bc123df4567
+          schema:
+            $ref: '#/components/schemas/Druid'
+  /objects/{druid}/versionClose: # post - //objects/druid:vy293gd2473/versionClose?create-accession=false&version=16
+    post:
+      summary: TODO
+      responses:
+        '200':
+          description: Request succeeded
+      parameters:
+        - name: druid
+          in: path
+          required: true
+          example: druid:bc123df4567
+          schema:
+            $ref: '#/components/schemas/Druid'
+        - name: create-accession
+          in: query
+          required: false
+          schema:
+            type: boolean
+        - name: version
+          in: query
+          required: true
+          schema:
+            type: integer 
+  /objects/{druid}/workflows/{workflow}: # post - //objects/druid:qr023rk8145/workflows/registrationWF?lane-id=default&version=1
+    post:
+      summary: Add provided workflow to object
+      responses:
+        '200':
+          description: Request succeeded
+      parameters:
+        - name: druid
+          in: path
+          required: true
+          example: druid:bc123df4567
+          schema:
+            $ref: '#/components/schemas/Druid'
+        - name: workflow
+          in: path
+          required: true
+          example: accessionWF
+          schema:
+            $ref: '#/components/schemas/Workflow'  
+  /objects/{druid}/workflows/{workflow}/{process}: # put - //objects/druid:vy293gd2473/workflows/assemblyWF/content-metadata-create
+    put:
+      summary: TODO
+      responses:
+        '200':
+          description: Request succeeded
+      parameters:
+        - name: druid
+          in: path
+          required: true
+          example: druid:bc123df4567
+          schema:
+            $ref: '#/components/schemas/Druid'
+        - name: workflow
+          in: path
+          required: true
+          example: accessionWF
+          schema:
+            $ref: '#/components/schemas/Workflow'  
+        - name: process
+          in: path
+          required: true
+          example: publish
+          schema:
+            $ref: '#/components/schemas/Process'
+  /workflow_templates/{workflow}: # get - //workflow_templates/registrationWF
+    get:
+      summary: Retrieve workflow template for given workflow
+      responses:
+        '200':
+          description: Workflow datastream found
+          content:
+            application/json:
+              schema:
+                type: string
+      parameters:
+        - name: workflow
+          in: path
+          required: true
+          example: accessionWF
+          schema:
+            $ref: '#/components/schemas/Workflow'
+  /workflow_archive: # get - DOES NOT LOOK USED
+    get:
+      summary: TODO
+      responses:
+        '200':
+          description: TODO
+          content:
+            application/xml:
+              schema:
+                type: string
+      parameters:
+        - name: workflow
+          in: query
+          required: false
+          example: accessionWF
+          schema:
+            $ref: '#/components/schemas/Workflow'
+  /workflow_queue: # get - //workflow_queue?completed=dor%3AetdSubmitWF%3Asubmit-marc&lane-id=default&waiting=dor%3AetdSubmitWF%3Acheck-marc
+    get:
+      summary: TODO
+      responses:
+        '200':
+          description: TODO
+          content:
+            application/xml:
+              schema:
+                type: string
+      parameters:
+        - name: completed
+          in: query
+          required: true
+          example: dor:etdSubmitWF:catalog-status
+          schema:
+            type: string
+        - name: waiting
+          in: query
+          required: false
+          example: dor:etdSubmitWF:catalog-status
+          schema:
+            type: string
+  /workflow_queue/lane_ids: # get - //workflow_queue/lane_ids?step=dor%3AetdSubmitWF%3Acheck-marc (dor:etdSubmit:check-marc)
+    get:
+      summary: TODO
+      responses:
+        '200':
+          description: TODO
+          content:
+            application/xml:
+              schema:
+                type: string
+      parameters:
+        - name: step
+          in: query
+          required: true
+          example: dor:etdSubmitWF:catalog-status
+          schema:
+            type: string
+  /workflow_queue/all_queued: # get - DO NOT SEE IN LOGS
+    get:
+      summary: TODO
+      responses:
+        '200':
+          description: TODO
+          content:
+            application/xml:
+              schema:
+                type: string
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          example: '10'
+          schema:
+            type: string
+components:
+  schemas:
+    Druid:
+      description: Digital Repository Unique Identifier (bare or prefixed)
+      type: string
+      pattern: '^(druid:)?[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}$'
+      example: 'druid:bc123df4567'
+    Process:
+      description: Process name
+      type: string
+      enum: [accessioning-initiate, approve, check-marc, checksum-compute, complete-ingest, content-metadata,
+              content-metadata-create, descriptive-metadata, end-accession, exif-collect, jp2-create, preservation-ingest-initiated,
+              provenance-metadata, publish, publish-complete, reader-approval, registrar-approval, remediate-object,
+              reset-workspace, rights-metadata, sdr-ingest-received, sdr-ingest-transfer, shelve, shelve-complete,
+              start-assembly, submit, technical-metadata, transfer-object, update-catalog, update-moab, validate-bag, verify-apo]
+    Repository:
+      description: Repository Identifier
+      type: string
+      enum: [dor]
+    Workflow:
+      description: Workflow name
+      type: string
+      enum: [accession2WF, dpgImageWF, gisDiscoveryWF, preservationIngestWF, sdrMigrationWF, wasCrawlPreassemblyWF,
+             accessionWF, eemsAccessionWF, goobiWF, registrationWF, sdrRecoveryWF, wasDisseminationWF,
+             assemblyWF, etdSubmitWF, googleScannedBookWF, releaseWF, swIndexWF, wasSeedDisseminationWF,
+             digitizationWF, gisAssemblyWF, hydrusAssemblyWF, sdrAuditWF, versioningWF, wasSeedPreassemblyWF,
+             disseminationWF, gisDeliveryWF, preservationAuditWF, sdrIngestWF, wasCrawlDisseminationWF]

--- a/openapi.yml
+++ b/openapi.yml
@@ -404,7 +404,12 @@ paths:
           content:
             application/json:
               schema:
-                type: string
+                type: array
+                items:
+                  type: object
+                  properties:
+                    externalIdentifier:
+                      $ref: '#/components/schemas/Workflow'
   /workflow_templates/{workflow}:
     get:
       summary: Retrieve workflow template for given workflow

--- a/openapi.yml
+++ b/openapi.yml
@@ -31,6 +31,7 @@ paths:
   /{repo}/objects/{druid}/lifecycle:
     get:
       summary: Retrieve workflow lifecycle for an object
+      deprecated: true
       responses:
         '200':
           description: Workflow lifecycle found
@@ -59,6 +60,7 @@ paths:
   /{repo}/objects/{druid}/versionClose:
     post:
       summary: Close the current version of the provided druid
+      deprecated: true
       responses:
         '200':
           description: Request succeeded
@@ -88,6 +90,7 @@ paths:
   /{repo}/objects/{druid}/workflows:
     get:
       summary: Retrieve workflow datastream for an object
+      deprecated: true
       responses:
         '200':
           description: Workflow datastream found
@@ -110,6 +113,7 @@ paths:
             $ref: '#/components/schemas/Druid'
     delete:
       summary: Delete all of the workflows for an object
+      deprecated: true
       responses:
         '204':
           description: No Content
@@ -129,6 +133,7 @@ paths:
   /{repo}/objects/{druid}/workflows/{workflow}:
     get:
       summary: Show the named workflow for a given druid
+      deprecated: true
       responses:
         '200':
           description: List of workflow steps
@@ -157,6 +162,7 @@ paths:
             $ref: '#/components/schemas/Workflow'  
     put:
       summary: Add provided workflow to object
+      deprecated: true
       responses:
         '200':
           description: Request succeeded
@@ -181,6 +187,7 @@ paths:
             $ref: '#/components/schemas/Workflow'
     delete:
       summary: Delete the workflow from the object
+      deprecated: true
       responses:
         '200':
           description: Request succeeded
@@ -206,6 +213,7 @@ paths:
   /{repo}/objects/{druid}/workflows/{workflow}/{process}:
     get:
       summary: Retrieve the process steps for the provided workflow and druid
+      deprecated: true
       responses:
         '200':
           description: List of process steps
@@ -240,6 +248,7 @@ paths:
             $ref: '#/components/schemas/Process'          
     put:
       summary: Add a process to the provided workflow and druid
+      deprecated: true
       responses:
         '200':
           description: Request succeeded
@@ -505,6 +514,7 @@ components:
              update-catalog, update-moab, validate-bag, verify-apo]
     Repository:
       description: Repository Identifier
+      deprecated: true
       type: string
       enum: [dor]
     Workflow:

--- a/openapi.yml
+++ b/openapi.yml
@@ -462,6 +462,18 @@ paths:
           example: dor:etdSubmitWF:catalog-status
           schema:
             type: string
+        - name: lane-id
+          in: query
+          required: false
+          example: default
+          schema:
+            type: string
+        - name: workflow
+          in: query
+          required: false
+          example: accessionWF
+          schema:
+            $ref: '#/components/schemas/Workflow'
   /workflow_queue/lane_ids:
     get:
       summary: Retrieve the workflow queue based on the provided lane_id
@@ -496,6 +508,12 @@ paths:
           example: '10'
           schema:
             type: string
+        - name: hours-ago
+          in: query
+          required: false
+          example: 1
+          schema:
+            type: integer
 components:
   schemas:
     Druid:

--- a/openapi.yml
+++ b/openapi.yml
@@ -487,11 +487,12 @@ components:
     Process:
       description: Process name
       type: string
-      enum: [start-accession, accessioning-initiate, approve, check-marc, checksum-compute, complete-ingest, content-metadata,
-             content-metadata-create, descriptive-metadata, end-accession, exif-collect, jp2-create, preservation-ingest-initiated,
-             provenance-metadata, publish, publish-complete, reader-approval, registrar-approval, remediate-object,
-             reset-workspace, rights-metadata, sdr-ingest-received, sdr-ingest-transfer, shelve, shelve-complete,
-             start-assembly, submit, technical-metadata, transfer-object, update-catalog, update-moab, validate-bag, verify-apo]
+      enum: [accessioning-initiate, approve, check-marc, checksum-compute, complete-ingest, content-metadata,
+             content-metadata-create, descriptive-metadata, end-accession, exif-collect, jp2-create,
+             preservation-ingest-initiated, provenance-metadata, publish, publish-complete, reader-approval,
+             registrar-approval, remediate-object, reset-workspace, rights-metadata, sdr-ingest-received, sdr-ingest-transfer,
+             shelve, shelve-complete, start-accession, start-assembly, submit, technical-metadata, transfer-object, 
+             update-catalog, update-moab, validate-bag, verify-apo]
     Repository:
       description: Repository Identifier
       type: string
@@ -499,8 +500,7 @@ components:
     Workflow:
       description: Workflow name
       type: string
-      enum: [accession2WF, dpgImageWF, gisDiscoveryWF, preservationIngestWF, sdrMigrationWF, wasCrawlPreassemblyWF,
-             accessionWF, eemsAccessionWF, goobiWF, registrationWF, sdrRecoveryWF, wasDisseminationWF,
-             assemblyWF, etdSubmitWF, googleScannedBookWF, releaseWF, swIndexWF, wasSeedDisseminationWF,
-             digitizationWF, gisAssemblyWF, hydrusAssemblyWF, sdrAuditWF, versioningWF, wasSeedPreassemblyWF,
-             disseminationWF, gisDeliveryWF, preservationAuditWF, sdrIngestWF, wasCrawlDisseminationWF]
+      enum: [accession2WF, accessionWF, assemblyWF, digitizationWF, disseminationWF, dpgImageWF, eemsAccessionWF, etdSubmitWF,
+             gisAssemblyWF, gisDeliveryWF, gisDiscoveryWF, goobiWF, googleScannedBookWF, hydrusAssemblyWF, preservationAuditWF,
+             preservationIngestWF, registrationWF, releaseWF, sdrAuditWF, sdrIngestWF, sdrMigrationWF, sdrRecoveryWF, swIndexWF,
+             versioningWF, wasCrawlDisseminationWF, wasCrawlPreassemblyWF, wasDisseminationWF, wasSeedDisseminationWF, wasSeedPreassemblyWF]

--- a/openapi.yml
+++ b/openapi.yml
@@ -48,7 +48,7 @@ paths:
             type: boolean
   /{repo}/objects/{druid}/versionClose:
     post:
-      summary: TODO
+      summary: Close the current version of the provided druid
       responses:
         '200':
           description: Request succeeded
@@ -195,7 +195,7 @@ paths:
             $ref: '#/components/schemas/Workflow'
   /{repo}/objects/{druid}/workflows/{workflow}/{process}:
     get:
-      summary: TODO
+      summary: Retrieve the process steps for the provided workflow and druid
       responses:
         '200':
           description: List of process steps
@@ -229,7 +229,7 @@ paths:
           schema:
             $ref: '#/components/schemas/Process'          
     put:
-      summary: TODO
+      summary: Add a process to the provided workflow and druid
       responses:
         '200':
           description: Request succeeded
@@ -289,7 +289,7 @@ paths:
             $ref: '#/components/schemas/Druid'
   /objects/{druid}/versionClose:
     post:
-      summary: TODO
+      summary: Close the current version of the provided druid
       responses:
         '200':
           description: Request succeeded
@@ -353,7 +353,7 @@ paths:
             $ref: '#/components/schemas/Workflow'  
   /objects/{druid}/workflows/{workflow}/{process}:
     put:
-      summary: TODO
+      summary: Add a process to the provided workflow and druid
       responses:
         '200':
           description: Request succeeded
@@ -405,10 +405,10 @@ paths:
             $ref: '#/components/schemas/Workflow'
   /workflow_archive:
     get:
-      summary: TODO
+      summary: Retrieve archived workflows
       responses:
         '200':
-          description: TODO
+          description: Request succeeded
           content:
             application/xml:
               schema:
@@ -422,10 +422,10 @@ paths:
             $ref: '#/components/schemas/Workflow'
   /workflow_queue:
     get:
-      summary: TODO
+      summary: Retrieve the workflow queue
       responses:
         '200':
-          description: TODO
+          description: Request succeeded
           content:
             application/xml:
               schema:
@@ -445,10 +445,10 @@ paths:
             type: string
   /workflow_queue/lane_ids:
     get:
-      summary: TODO
+      summary: Retrieve the workflow queue based on the provided lane_id
       responses:
         '200':
-          description: TODO
+          description: Request succeeded
           content:
             application/xml:
               schema:
@@ -462,10 +462,10 @@ paths:
             type: string
   /workflow_queue/all_queued:
     get:
-      summary: TODO
+      summary: Retrieve the workflow queue for all queues
       responses:
         '200':
-          description: TODO
+          description: Request succeeded
           content:
             application/xml:
               schema:

--- a/spec/requests/lifecycle_spec.rb
+++ b/spec/requests/lifecycle_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe 'Lifecycle', type: :request do
       end
 
       it 'draws milestones from the current version' do
-        get "/objects/#{druid}/lifecycle?active-only=true&version=2"
+        get "/dor/objects/#{druid}/lifecycle?active-only=true&version=2"
         expect(returned_milestone_versions).to eq ['2']
         expect(returned_milestone_text).to eq ['submitted']
       end
@@ -103,7 +103,7 @@ RSpec.describe 'Lifecycle', type: :request do
     end
 
     it 'draws milestones from the all versions' do
-      get "/objects/#{druid}/lifecycle"
+      get "/dor/objects/#{druid}/lifecycle"
       expect(returned_milestone_versions).to match_array %w[1 2]
       expect(returned_milestone_text).to match_array %w[submitted submitted]
     end

--- a/spec/requests/show_workflow_template_spec.rb
+++ b/spec/requests/show_workflow_template_spec.rb
@@ -26,10 +26,9 @@ RSpec.describe 'Show a workflow template', type: :request do
   end
 
   context 'for an nonexistent template' do
-    it 'returns 404' do
+    it 'returns 400' do
       get '/workflow_templates/foo'
-
-      expect(response).to have_http_status(:not_found)
+      expect(response).to have_http_status(:bad_request)
     end
   end
 end

--- a/spec/requests/workflows/show_step_spec.rb
+++ b/spec/requests/workflows/show_step_spec.rb
@@ -22,10 +22,9 @@ RSpec.describe 'Show a workflow step for an object', type: :request do
   end
 
   context 'when step does not exist' do
-    it 'returns 404' do
+    it 'returns 400' do
       get "/dor/objects/#{step.druid}/workflows/#{step.workflow}/#{step.process}x"
-
-      expect(response).to be_not_found
+      expect(response).to have_http_status(:bad_request)
     end
   end
 end

--- a/spec/requests/workflows/single_workflow_for_object_spec.rb
+++ b/spec/requests/workflows/single_workflow_for_object_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Get a single workflow for an object', type: :request do
     end
 
     context 'when no workflow exists' do
-      let(:druid) { 'druid:abc1232' }
+      let(:druid) { 'druid:bb123bc1234' }
 
       it 'returns an empy workflow node' do
         get "/dor/objects/#{druid}/workflows/accessionWF"
@@ -65,7 +65,7 @@ RSpec.describe 'Get a single workflow for an object', type: :request do
     end
 
     context 'when no workflow exists' do
-      let(:druid) { 'druid:bb123bb12342' }
+      let(:druid) { 'druid:bb123bb1234' }
 
       it 'returns an empy workflow node' do
         get "/objects/#{druid}/workflows/accessionWF"

--- a/spec/requests/workflows/update_step_spec.rb
+++ b/spec/requests/workflows/update_step_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe 'Update a workflow step for an object', type: :request do
 
     it 'clears the old error message, but preserves the lifecycle' do
       put "/dor/objects/#{druid}/workflows/#{wf.workflow}/#{wf.process}", params: process_xml
-
       wf.reload
       expect(wf.status).to eq 'completed'
       expect(wf.error_msg).to be_nil


### PR DESCRIPTION
## Why was this change made?

Fixes #349 

This:

- Adds openapi.yml to the repository
- Validates openapi.yml in the circleci build
- Fixes test responses based on openapi validation of requests
- Adds the openapi validator badge to the readme
- Adds a docs folder (to be enabled after merging in github pages)

## Was the documentation (API, README, DevOpsDocs, wiki, consul, etc.) updated?

README - Badge added

/docs folder added to populate github pages

## Does this change affect how this application integrates with other services?

I trolled the stage and prod logs to verify all paths were captured. It may be prudent to deploy this to stage and run the integration tests, but any one-off requests may still be missed.
