### PR TITLE
Add lifecylce endpoint to non repo route

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ To shut down postgres afterwards,
 ## Routes:
 `GET    /:repo/objects/:druid/lifecycle` - Returns the milestones in the lifecycle that have been completed
 
+`GET    /objects/:druid/lifecycle` - Returns the milestones in the lifecycle that have been completed
+
 
 `POST   /:repo/objects/:druid/versionClose` - Set all versioningWF steps to 'complete' and starts a new accessionWF unless `create-accession=false` is passed as a parameter.
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
   end
 
   scope 'objects/:druid', constraints: { druid: %r{[^\/]+} }, defaults: { format: :xml } do
+    get 'lifecycle', to: 'workflows#lifecycle'
     delete 'workflows', to: 'steps#destroy_all'
     post 'versionClose', to: 'versions#close'
 

--- a/spec/requests/lifecycle_spec.rb
+++ b/spec/requests/lifecycle_spec.rb
@@ -42,14 +42,14 @@ RSpec.describe 'Lifecycle', type: :request do
       context 'when version is not passed (deprecated)' do
         it 'draws an empty set of milestones and notifies honeybadger' do
           expect(Honeybadger).to receive(:notify)
-          get "/dor/objects/#{druid}/lifecycle?active-only=true"
+          get "/objects/#{druid}/lifecycle?active-only=true"
           expect(returned_milestone_versions).to eq []
         end
       end
 
       context 'when version is passed' do
         it 'draws an empty set of milestones' do
-          get "/dor/objects/#{druid}/lifecycle?active-only=true&version=2"
+          get "/objects/#{druid}/lifecycle?active-only=true&version=2"
           expect(returned_milestone_versions).to eq []
         end
       end
@@ -77,7 +77,7 @@ RSpec.describe 'Lifecycle', type: :request do
         it 'draws milestones from the current version and notifies honeybadger' do
           expect(Honeybadger).to receive(:notify)
 
-          get "/dor/objects/#{druid}/lifecycle?active-only=true"
+          get "/objects/#{druid}/lifecycle?active-only=true"
           expect(returned_milestone_versions).to eq ['2']
           expect(returned_milestone_text).to eq ['submitted']
         end
@@ -85,7 +85,7 @@ RSpec.describe 'Lifecycle', type: :request do
 
       context 'when version is passed' do
         it 'draws milestones from the current version' do
-          get "/dor/objects/#{druid}/lifecycle?active-only=true&version=2"
+          get "/objects/#{druid}/lifecycle?active-only=true&version=2"
           expect(returned_milestone_versions).to eq ['2']
           expect(returned_milestone_text).to eq ['submitted']
         end
@@ -129,7 +129,7 @@ RSpec.describe 'Lifecycle', type: :request do
     end
 
     it 'draws milestones from the all versions' do
-      get "/dor/objects/#{druid}/lifecycle"
+      get "/objects/#{druid}/lifecycle"
       expect(returned_milestone_versions).to match_array %w[1 2]
       expect(returned_milestone_text).to match_array %w[submitted submitted]
     end


### PR DESCRIPTION
## Why was this change made?

The lifecycle route provides the information necessary to use the workflow-service for the milestone display in argo, however, it is not currently available without the repo parameter which we are trying to deprecate. 

## Was the documentation (API, README, DevOpsDocs, wiki, consul, etc.) updated?

README

## Does this change affect how this application integrates with other services?

No, not currently used.