### PR TITLE
Skip the etd other-metadata and start-accession

### DIFF
--- a/config/workflows/etdSubmitWF.xml
+++ b/config/workflows/etdSubmitWF.xml
@@ -24,11 +24,11 @@
     <label>Monitor Symphony status until Cataloging is done</label>
     <prereq>check-marc</prereq>
   </process>
-  <process name="other-metadata" sequence="8">
+  <process name="other-metadata" sequence="8" skip-queue="true">
     <label>Generate content, technical and rights metadata</label>
     <prereq>catalog-status</prereq>
   </process>
-  <process name="start-accession" sequence="9">
+  <process name="start-accession" sequence="9" skip-queue="true">
     <label>Transfer control to Common Accessioning</label>
     <prereq>other-metadata</prereq>
   </process>


### PR DESCRIPTION


## Why was this change made?
This means they won't get enqueued into the Resque instance for robots and  allows them to move to hydra-etd application.


## Was the documentation (API, README, DevOpsDocs, wiki, consul, etc.) updated?

no.

## Does this change affect how this application integrates with other services?

no
If so, please confirm:
- [ ] change was tested on stage    and/or
- [ ] test added to sul-dlss/infrastructure-integration-test
