### PR TITLE
Ignore repository argument

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,3 +17,12 @@ Metrics/BlockLength:
 Metrics/MethodLength:
   Exclude:
     - db/migrate/*
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'rspec-rails', '4.0.0.beta4'
   gem 'rspec_junit_formatter'
-  gem 'rubocop'
+  gem 'rubocop', '~> 0.80.1'
   # Codeclimate is not compatible with 0.18+. See https://github.com/codeclimate/test-reporter/issues/413
   gem 'simplecov', '~> 0.17.1'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -371,7 +371,7 @@ DEPENDENCIES
   resque (~> 2.0)
   rspec-rails (= 4.0.0.beta4)
   rspec_junit_formatter
-  rubocop
+  rubocop (~> 0.80.1)
   simplecov (~> 0.17.1)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/controllers/workflow_queues_controller.rb
+++ b/app/controllers/workflow_queues_controller.rb
@@ -50,7 +50,7 @@ class WorkflowQueuesController < ApplicationController
   end
 
   def workflows_for_step_and_scope(step, scope)
-    _repository, workflow, process = step.split(':')
+    workflow, process = step.split(':').last(2)
 
     WorkflowStep.active.public_send(scope).where(workflow: workflow, process: process)
   end

--- a/spec/requests/lanes_spec.rb
+++ b/spec/requests/lanes_spec.rb
@@ -26,9 +26,23 @@ RSpec.describe 'Lanes', type: :request do
                       active_version: true)
   end
 
-  it 'shows the lanes' do
-    get '/workflow_queue/lane_ids?step=dor:accessionWF:shelve'
+  let(:expected_xml) do
+    '<lanes><lane id="default"/><lane id="fast"/></lanes>'
+  end
 
-    expect(response.body).to be_equivalent_to '<lanes><lane id="default"/><lane id="fast"/></lanes>'
+  context 'with repository-qualified step names' do
+    it 'shows the lanes' do
+      get '/workflow_queue/lane_ids?step=dor:accessionWF:shelve'
+
+      expect(response.body).to be_equivalent_to expected_xml
+    end
+  end
+
+  context 'without repository-qualified step names' do
+    it 'shows the lanes' do
+      get '/workflow_queue/lane_ids?step=accessionWF:shelve'
+
+      expect(response.body).to be_equivalent_to expected_xml
+    end
   end
 end

--- a/spec/requests/queues/all_queued_spec.rb
+++ b/spec/requests/queues/all_queued_spec.rb
@@ -16,6 +16,15 @@ RSpec.describe 'All queued steps', type: :request do
                       status: 'queued')
   end
 
+  let(:expected_xml) do
+    <<~XML
+      <workflows>
+        <workflow name="accessionWF" process="shelve" druid="#{one.druid}" laneId="default"/>
+        <workflow name="accessionWF" process="shelve-complete" druid="#{two.druid}" laneId="fast"/>
+      </workflows>
+    XML
+  end
+
   let!(:one) do
     FactoryBot.create(:workflow_step,
                       process: 'shelve',
@@ -31,14 +40,19 @@ RSpec.describe 'All queued steps', type: :request do
                       updated_at: 3.days.ago)
   end
 
-  it 'shows all the queued items' do
-    get '/workflow_queue/all_queued?repository=dor&limit=3&hours-ago=24'
+  context 'with repository query arg' do
+    it 'shows all the queued items' do
+      get '/workflow_queue/all_queued?repository=dor&limit=3&hours-ago=24'
 
-    expect(response.body).to be_equivalent_to <<~XML
-      <workflows>
-        <workflow name="accessionWF" process="shelve" druid="#{one.druid}" laneId="default"/>
-        <workflow name="accessionWF" process="shelve-complete" druid="#{two.druid}" laneId="fast"/>
-      </workflows>
-    XML
+      expect(response.body).to be_equivalent_to expected_xml
+    end
+  end
+
+  context 'without repository query arg' do
+    it 'shows all the queued items' do
+      get '/workflow_queue/all_queued?limit=3&hours-ago=24'
+
+      expect(response.body).to be_equivalent_to expected_xml
+    end
   end
 end


### PR DESCRIPTION
Connects to sul-dlss/preservation_robots#207 
Connects to sul-dlss/dor-workflow-client#159

## Why was this change made?

It enables dor-workflow-client to stop sending workflow steps qualified with (unused) repository names.

As part of this work, expand testing of repo-ful and repo-less interactions

## Was the documentation (API, README, DevOpsDocs, wiki, consul, etc.) updated?

No.

## Does this change affect how this application integrates with other services?

It makes sure the workflow service can operate when passed repository arguments and when not passed repository arguments.