### PR TITLE
Fixed lane-id param when creating workflow.

### DIFF
--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -7,7 +7,7 @@ class StepsController < ApplicationController
   # If there are next steps, they are enqueued.
   # rubocop:disable Metrics/AbcSize
   def update
-    parser = ProcessParser.new(process_from_request_body)
+    parser = ProcessParser.new(process_from_request_body, use_default_lane_id: false)
     step = find_step_for_process
 
     return render plain: '', status: :not_found if step.nil?

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -91,7 +91,7 @@ class WorkflowsController < ApplicationController
 
   def initial_parser
     @initial_parser ||= begin
-      initial_workflow = WorkflowTransformer.initial_workflow(template, params[:lane_id])
+      initial_workflow = WorkflowTransformer.initial_workflow(template, params[:'lane-id'])
       InitialWorkflowParser.new(initial_workflow)
     end
   end

--- a/app/services/process_parser.rb
+++ b/app/services/process_parser.rb
@@ -3,7 +3,7 @@
 ##
 # Parsing Process creation request
 class ProcessParser
-  attr_reader :process_element
+  attr_reader :process_element, :use_default_lane_id
 
   PROCESS_ATTRIBUTES = %i[
     process
@@ -24,8 +24,10 @@ class ProcessParser
 
   ##
   # @param [Nokogiri::XML::Element] process_element
-  def initialize(process_element)
+  # @param [Boolean] use_default_lane_id provide "default" as lane_id if no lane_id
+  def initialize(process_element, use_default_lane_id: true)
     @process_element = process_element
+    @use_default_lane_id = use_default_lane_id
   end
 
   # Convert the xml to a hash suitable for creating or updating the model.
@@ -50,7 +52,10 @@ class ProcessParser
   end
 
   def lane_id
-    process_element.attr('laneId') || 'default'
+    lane_id_attr = process_element.attr('laneId')
+    return lane_id_attr unless lane_id_attr.nil?
+
+    use_default_lane_id ? 'default' : nil
   end
 
   def lifecycle

--- a/spec/requests/workflows/create_workflow_spec.rb
+++ b/spec/requests/workflows/create_workflow_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe 'Create a workflow' do
       end
 
       it 'sets the lane id' do
-        post "/objects/#{druid}/workflows/#{workflow}?lane_id=#{lane_id}&version=1"
+        post "/objects/#{druid}/workflows/#{workflow}?lane-id=#{lane_id}&version=1"
         expect(WorkflowStep.last.lane_id).to eq(lane_id)
       end
 


### PR DESCRIPTION
closes #359

## Why was this change made?
So that the lane-id param matches the param passed by workflow client.


## Was the documentation (API, README, DevOpsDocs, wiki, consul, etc.) updated?
No.


## Does this change affect how this application integrates with other services?
If so, please confirm:
- change was tested on stage    and/or
- test added to sul-dlss/infrastructure-integration-test
Tested on stage.