### PR TITLE
Upgrade to ruby 2.7.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 jobs:
   test:
     docker:
-    - image: circleci/ruby:2.5.3-stretch-node
+    - image: circleci/ruby:2.7.1-node
       environment:
         BUNDLE_JOBS: 3
         BUNDLE_RETRY: 3

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,6 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.5.3'
-
 gem 'rails', '~> 6.0.2'
 
 gem 'activerecord-import' # we can remove this after we've migrated the data

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -390,8 +390,5 @@ DEPENDENCIES
   stomp (~> 1.4)
   whenever
 
-RUBY VERSION
-   ruby 2.5.3p105
-
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
## Why was this change made?

The new servers install 2.7.1 by default

## Was the documentation (API, README, DevOpsDocs, wiki, consul, etc.) updated?
no


## Does this change affect how this application integrates with other services?
no
If so, please confirm:
- change was tested on stage    and/or
- test added to sul-dlss/infrastructure-integration-test
