### PR TITLE
use alpine build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.1
+FROM ruby:2.7.1-alpine
 
 # postgresql-client is required for invoke.sh
 RUN apk --no-cache add \


### PR DESCRIPTION
## Why was this change made?

to fix the circleci build and avoid:

```
/bin/sh: 1: apk: not found
 
The command '/bin/sh -c apk --no-cache add   postgresql-dev   postgresql-client   tzdata' returned a non-zero code: 127
 ```

## Was the documentation (API, README, DevOpsDocs, wiki, consul, etc.) updated?



## Does this change affect how this application integrates with other services?

If so, please confirm:
- change was tested on stage    and/or
- test added to sul-dlss/infrastructure-integration-test
