### PR TITLE
Added custom whenever job_type to remove deprecated warnings

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -20,7 +20,8 @@
 # end
 
 # Learn more: http://github.com/javan/whenever
+job_type :no_warnings_runner, "cd :path && RUBYOPT='-W0' bundle exec bin/rails runner -e :environment ':task' :output"
 
 every 60.minutes do
-  runner 'Sweeper.sweep'
+  no_warnings_runner 'Sweeper.sweep'
 end


### PR DESCRIPTION
## Why was this change made?
To prevent Cron job created with whenever to send out warning emails and messages over depreciated calls with Ruby 2.7.1. 


## Was the documentation (API, README, DevOpsDocs, wiki, consul, etc.) updated?
n/a


## Does this change affect how this application integrates with other services?

If so, please confirm:
- change was tested on stage    and/or
- test added to sul-dlss/infrastructure-integration-test
