### PR TITLE
[HOLD] Remove preservation-ingest-initiated step from accessionWF

### DIFF
--- a/config/workflows/accessionWF.xml
+++ b/config/workflows/accessionWF.xml
@@ -39,19 +39,16 @@
     <label>Initiate Ingest into Preservation</label>
     <prereq>provenance-metadata</prereq>
   </process>
-  <process batch-limit="1" error-limit="5" name="preservation-ingest-initiated" sequence="11" skip-queue="true">
-    <label>Signal that preservation ingest has been initiated</label>
-  </process>
-  <process batch-limit="1" error-limit="5" lifecycle="deposited" name="sdr-ingest-received" sequence="12" skip-queue="true">
+  <process batch-limit="1" error-limit="5" lifecycle="deposited" name="sdr-ingest-received" sequence="11" skip-queue="true">
     <label>Signal from SDR that object has been received</label>
   </process>
-  <process batch-limit="1" error-limit="5" name="reset-workspace" sequence="13">
+  <process batch-limit="1" error-limit="5" name="reset-workspace" sequence="12">
     <label>Reset workspace by renaming the druid-tree to a versioned directory</label>
     <prereq>sdr-ingest-received</prereq>
     <prereq>provenance-metadata</prereq>
     <prereq>shelve</prereq>
   </process>
-  <process batch-limit="1" error-limit="5" lifecycle="accessioned" name="end-accession" sequence="14">
+  <process batch-limit="1" error-limit="5" lifecycle="accessioned" name="end-accession" sequence="13">
     <label>Clean up any diff caches and set disseminationWF:cleanup to waiting</label>
     <prereq>reset-workspace</prereq>
   </process>

--- a/spec/requests/version_close_spec.rb
+++ b/spec/requests/version_close_spec.rb
@@ -23,14 +23,14 @@ RSpec.describe 'Close a version', type: :request do
 
         post "/dor/objects/#{druid}/versionClose"
         expect(response).to be_successful
-        expect(WorkflowStep.where(druid: druid).count).to eq 14
+        expect(WorkflowStep.where(druid: druid).count).to eq 13
       end
     end
 
     it 'closes the version' do
       post "/objects/#{druid}/versionClose"
       expect(response).to be_successful
-      expect(WorkflowStep.where(druid: druid).count).to eq 14
+      expect(WorkflowStep.where(druid: druid).count).to eq 13
     end
   end
 
@@ -38,7 +38,7 @@ RSpec.describe 'Close a version', type: :request do
     it 'closes the version' do
       post "/objects/#{druid}/versionClose?version=3"
       expect(response).to be_successful
-      expect(WorkflowStep.where(druid: druid).count).to eq 14
+      expect(WorkflowStep.where(druid: druid).count).to eq 13
     end
   end
 end

--- a/spec/requests/workflows/create_workflow_spec.rb
+++ b/spec/requests/workflows/create_workflow_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Create a workflow' do
         headers = { 'CONTENT_TYPE' => 'application/xml' }
         expect do
           put "/#{repository}/objects/#{druid}/workflows/#{workflow}?version=1", params: request_data, headers: headers
-        end.to change(WorkflowStep, :count).by(14)
+        end.to change(WorkflowStep, :count).by(13)
 
         expect(SendUpdateMessage).to have_received(:publish).with(druid: druid)
       end
@@ -41,7 +41,7 @@ RSpec.describe 'Create a workflow' do
 
         expect do
           put "/#{repository}/objects/#{druid}/workflows/#{workflow}", params: request_data
-        end.to change(WorkflowStep, :count).by(14)
+        end.to change(WorkflowStep, :count).by(13)
 
         expect(SendUpdateMessage).to have_received(:publish).with(druid: druid)
       end
@@ -53,7 +53,7 @@ RSpec.describe 'Create a workflow' do
 
           expect do
             put "/#{repository}/objects/#{druid}/workflows/#{workflow}", params: request_data
-          end.to change(WorkflowStep, :count).by(14)
+          end.to change(WorkflowStep, :count).by(13)
         end
       end
     end
@@ -70,7 +70,7 @@ RSpec.describe 'Create a workflow' do
 
         expect do
           put "/#{repository}/objects/#{druid}/workflows/#{workflow}", params: request_data
-        end.to change(WorkflowStep, :count).by(14)
+        end.to change(WorkflowStep, :count).by(13)
 
         expect(SendUpdateMessage).to have_received(:publish).with(druid: druid)
       end
@@ -90,7 +90,7 @@ RSpec.describe 'Create a workflow' do
       it 'creates new workflows' do
         expect do
           post "/objects/#{druid}/workflows/#{workflow}?version=1"
-        end.to change(WorkflowStep, :count).by(14)
+        end.to change(WorkflowStep, :count).by(13)
         expect(WorkflowStep.last.lane_id).to eq('default')
         expect(SendUpdateMessage).to have_received(:publish).with(druid: druid)
       end
@@ -117,7 +117,7 @@ RSpec.describe 'Create a workflow' do
 
         expect do
           post "/objects/#{druid}/workflows/#{workflow}"
-        end.to change(WorkflowStep, :count).by(14)
+        end.to change(WorkflowStep, :count).by(13)
         expect(WorkflowStep.last.lane_id).to eq('default')
         expect(SendUpdateMessage).to have_received(:publish).with(druid: druid)
       end
@@ -135,7 +135,7 @@ RSpec.describe 'Create a workflow' do
 
         expect do
           post "/objects/#{druid}/workflows/#{workflow}"
-        end.to change(WorkflowStep, :count).by(14)
+        end.to change(WorkflowStep, :count).by(13)
 
         expect(SendUpdateMessage).to have_received(:publish).with(druid: druid)
       end

--- a/spec/services/initial_workflow_parser_spec.rb
+++ b/spec/services/initial_workflow_parser_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe InitialWorkflowParser do
 
     it 'is a list of ProcessParsers' do
       expect(processes).to all be_instance_of ProcessParser
-      expect(processes.size).to eq 14
+      expect(processes.size).to eq 13
     end
   end
 end

--- a/spec/services/workflow_creator_spec.rb
+++ b/spec/services/workflow_creator_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe WorkflowCreator do
     it 'creates a WorkflowStep for each process' do
       expect do
         create_workflow_steps
-      end.to change(WorkflowStep, :count).by(14)
+      end.to change(WorkflowStep, :count).by(13)
       expect(WorkflowStep.last.druid).to eq druid
       expect(QueueService).to have_received(:enqueue).with(WorkflowStep.find_by(druid: druid, process: 'descriptive-metadata'))
     end

--- a/spec/services/workflow_template_parser_spec.rb
+++ b/spec/services/workflow_template_parser_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe WorkflowTemplateParser do
     subject(:processes) { wf_parser.processes }
 
     it 'returns a list of process structs' do
-      expect(processes.length).to eq 14
+      expect(processes.length).to eq 13
       expect(processes).to all(be_an_instance_of(WorkflowTemplateParser::Process))
     end
   end

--- a/spec/services/workflow_transformer_spec.rb
+++ b/spec/services/workflow_transformer_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe WorkflowTransformer do
           <process name="publish" status="waiting"/>
           <process name="provenance-metadata" status="waiting"/>
           <process name="sdr-ingest-transfer" status="waiting"/>
-          <process name="preservation-ingest-initiated" status="waiting"/>
           <process name="sdr-ingest-received" status="waiting" lifecycle="deposited"/>
           <process name="reset-workspace" status="waiting"/>
           <process name="end-accession" status="waiting" lifecycle="accessioned"/>


### PR DESCRIPTION
## Why was this change made?
Part of https://github.com/sul-dlss/argo/issues/1789


## Was the documentation (API, README, DevOpsDocs, wiki, consul, etc.) updated?
no


## Does this change affect how this application integrates with other services?

change was tested on stage 

