### PR TITLE
Added back published milestone.

### DIFF
--- a/config/workflows/accessionWF.xml
+++ b/config/workflows/accessionWF.xml
@@ -27,7 +27,7 @@
     <label>Shelve content in Digital Stacks</label>
     <prereq>remediate-object</prereq>
   </process>
-  <process batch-limit="100" error-limit="10" name="publish" sequence="8">
+  <process batch-limit="100" error-limit="10" lifecycle="published" name="publish" sequence="8">
     <label>Publish Metadata</label>
     <prereq>shelve</prereq>
   </process>

--- a/spec/services/workflow_transformer_spec.rb
+++ b/spec/services/workflow_transformer_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe WorkflowTransformer do
           <process name="technical-metadata" status="waiting"/>
           <process name="remediate-object" status="waiting"/>
           <process name="shelve" status="waiting"/>
-          <process name="publish" status="waiting"/>
+          <process name="publish" status="waiting" lifecycle="published"/>
           <process name="provenance-metadata" status="waiting"/>
           <process name="sdr-ingest-transfer" status="waiting"/>
           <process name="sdr-ingest-received" status="waiting" lifecycle="deposited"/>


### PR DESCRIPTION
refs https://github.com/sul-dlss/argo/issues/2060

## Why was this change made?
So that the published lifecycle is provided in Argo display.


## How was this change tested?
Stage


## Which documentation and/or configurations were updated?
No


