### PR TITLE
Send an alert when sweeping possibly stale workflow steps

### DIFF
--- a/app/services/sweeper.rb
+++ b/app/services/sweeper.rb
@@ -17,9 +17,9 @@ class Sweeper
 
   def sweep_steps(steps)
     steps.each do |step|
-      step.update(status: 'waiting')
+      # step.update(status: 'waiting')
       notify_honeybadger(step)
-      enqueue_next_steps(step)
+      # enqueue_next_steps(step)
     end
   end
 

--- a/spec/services/sweeper_spec.rb
+++ b/spec/services/sweeper_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe Sweeper do
   before do
     allow(QueueService).to receive(:enqueue)
+    allow(Honeybadger).to receive(:notify)
   end
 
   describe '.sweep' do
@@ -76,12 +77,13 @@ RSpec.describe Sweeper do
                         active_version: true)
     end
 
-    it 'requeues the old steps' do
+    it 'notifies Honeybadger' do
       described_class.sweep
-      expect(QueueService).to have_received(:enqueue).exactly(3).times
-      expect(QueueService).to have_received(:enqueue).with(stale)
-      expect(QueueService).to have_received(:enqueue).with(less_stale)
-      expect(QueueService).to have_received(:enqueue).with(stale_started)
+      expect(Honeybadger).to have_received(:notify).exactly(3).times
+      # expect(QueueService).to have_received(:enqueue).exactly(3).times
+      # expect(QueueService).to have_received(:enqueue).with(stale)
+      # expect(QueueService).to have_received(:enqueue).with(less_stale)
+      # expect(QueueService).to have_received(:enqueue).with(stale_started)
     end
   end
 end


### PR DESCRIPTION

## Why was this change made?

Do this instead of taking automated action on such steps. Discussed today after stand-up. This should allow long-running jobs to finish without being prematurely swept.


## How was this change tested?

Unit test.

## Which documentation and/or configurations were updated?

None

