### PR TITLE
Send an alert when stale workflow steps are found

### DIFF
--- a/app/services/workflow_monitor.rb
+++ b/app/services/workflow_monitor.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Monitors stuck workflows
+class WorkflowMonitor
+  # Look for "queued" steps that are more than 12 hours old
+  # and "started" steps that are more than 24 hours old
+  def self.monitor
+    new.monitor
+  end
+
+  def monitor
+    monitor_queued_steps
+    monitor_started_steps
+  end
+
+  private
+
+  def monitor_started_steps
+    steps = WorkflowStep.started
+                        .where(WorkflowStep.arel_table[:updated_at].lt(24.hours.ago))
+                        .limit(1000)
+
+    steps.each do |step|
+      Honeybadger.notify("Workflow step has been running for more than 24 hours: <druid:\"#{step.druid}\" " \
+      "version:\"#{step.version}\" workflow:\"#{step.workflow}\" process:\"#{step.process}\">. " \
+      'Perhaps there is a problem with it.')
+    end
+  end
+
+  def monitor_queued_steps
+    queued_count = WorkflowStep.queued
+                               .where(WorkflowStep.arel_table[:updated_at].lt(12.hours.ago)).count
+    return if queued_count.zero?
+
+    Honeybadger.notify("#{queued_count} workflow steps have been queued for more than 12 hours. Perhaps there is a " \
+        'problem with the robots.')
+  end
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -23,5 +23,8 @@
 job_type :no_warnings_runner, "cd :path && RUBYOPT='-W0' bundle exec bin/rails runner -e :environment ':task' :output"
 
 every 60.minutes do
-  no_warnings_runner 'Sweeper.sweep'
+  # Currently running Monitor (notification only for stuck workflow steps) instead of Sweeper (notification and requeueing).
+  # If monitoring alone isn't adequate (e.g., due to large numbers of Redis timeouts), we may want to re-enable the sweeper.
+  # no_warnings_runner 'Sweeper.sweep'
+  no_warnings_runner 'WorkflowMonitor.monitor'
 end


### PR DESCRIPTION
Reverts part of #327


## Why was this change made?

Monitor potentially stale steps rather than taking automated action on them. We think we no longer need to sweep them aggressively, and this is causing long-running jobs to be restarted prematurely. Discussed today after stand-up.


## How was this change tested?

Unit tests

## Which documentation and/or configurations were updated?

None