### PR TITLE
use new completed_at date for milestones

### DIFF
--- a/app/models/workflow_step.rb
+++ b/app/models/workflow_step.rb
@@ -11,23 +11,49 @@ class WorkflowStep < ApplicationRecord
   validate  :workflow_exists, on: :create
   validate  :process_exists_for_workflow, on: :create
 
+  before_save :set_completed_at, if: :completed?
+
   scope :lifecycle, -> { where.not(lifecycle: nil) }
-  scope :incomplete, -> { where.not(status: %w[completed skipped]) }
-  scope :complete, -> { where(status: %w[completed skipped]) }
+  scope :incomplete, -> { where.not(status: COMPLETED_STATES) }
+  scope :complete, -> { where(status: COMPLETED_STATES) }
   scope :waiting, -> { where(status: 'waiting') }
   scope :queued, -> { where(status: 'queued') }
   scope :started, -> { where(status: 'started') }
   scope :active, -> { where(active_version: true) }
 
   scope :for_version, ->(version) { where(version: version) }
+
+  COMPLETED_STATES = %w[completed skipped].freeze # a list of states that are considered completed
   ##
   # Serialize a WorkflowStep as a milestone
   # @param [Nokogiri::XML::Builder] xml
   # @return [Nokogiri::XML::Builder::NodeBuilder]
   def as_milestone(xml)
     xml.milestone(lifecycle,
-                  date: created_at.to_time.iso8601,
+                  date: milestone_date,
                   version: version)
+  end
+
+  # callback to set the completed_at column to the current time if we are completing a step
+  def set_completed_at
+    self.completed_at = Time.now
+  end
+
+  ##
+  # indicate if this step is marked as completed
+  # @return [boolean]
+  def completed?
+    COMPLETED_STATES.include? status
+  end
+
+  ##
+  # this is the milestone completion date, which is listed as the date the row was created, or the date it was completed
+  def milestone_date
+    if completed_at
+      completed_at.to_time.iso8601
+    else
+      created_at.to_time.iso8601
+    end
   end
 
   ##

--- a/app/models/workflow_step.rb
+++ b/app/models/workflow_step.rb
@@ -26,7 +26,7 @@ class WorkflowStep < ApplicationRecord
   # @return [Nokogiri::XML::Builder::NodeBuilder]
   def as_milestone(xml)
     xml.milestone(lifecycle,
-                  date: updated_at.to_time.iso8601,
+                  date: created_at.to_time.iso8601,
                   version: version)
   end
 

--- a/db/migrate/20200811212454_workflow_step_completed_at.rb
+++ b/db/migrate/20200811212454_workflow_step_completed_at.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class WorkflowStepCompletedAt < ActiveRecord::Migration[6.0]
+  def change
+    add_column :workflow_steps, :completed_at, :datetime, null: true
+
+    # defaults all completed current rows to set the completed_at to the last time they were updated, new rows will be set accordingly
+    reversible do |dir|
+      dir.up { WorkflowStep.complete.update_all('completed_at = updated_at') }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_14_185747) do
+ActiveRecord::Schema.define(version: 2020_08_11_212454) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 2019_11_14_185747) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "active_version", default: false
+    t.datetime "completed_at"
     t.index ["active_version", "status", "workflow", "process"], name: "active_version_step_name_workflow2_idx"
     t.index ["druid", "version"], name: "index_workflow_steps_on_druid_and_version"
     t.index ["druid"], name: "index_workflow_steps_on_druid"

--- a/spec/factories/workflow_steps.rb
+++ b/spec/factories/workflow_steps.rb
@@ -10,5 +10,10 @@ FactoryBot.define do
     version { 1 }
     lane_id { 'default' }
     status { 'waiting' }
+
+    trait :completed do
+      status { 'completed' }
+      completed_at { Time.now }
+    end
   end
 end

--- a/spec/models/workflow_step_spec.rb
+++ b/spec/models/workflow_step_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe WorkflowStep do
+  let(:completed_step) { FactoryBot.create(:workflow_step, :completed) }
+
   subject(:step) do
     FactoryBot.create(
       :workflow_step,
@@ -129,6 +131,31 @@ RSpec.describe WorkflowStep do
       it "is not valid if the version is #{invalid_version}" do
         expect { step.version = invalid_version }.to change { step.valid? }.from(true).to(false)
       end
+    end
+  end
+
+  describe '#completed?' do
+    it 'indicates if the step is not completed' do
+      expect(step.completed?).to be_falsey
+    end
+
+    it 'indicates if the step is completed' do
+      expect(completed_step.completed?).to be_truthy
+    end
+  end
+
+  describe '#milestone_date' do
+    it 'returns created_at if completed_at is nil' do
+      expect(step.completed_at).to be_nil
+      expect(step.milestone_date).to eq step.created_at.to_time.iso8601
+    end
+
+    it 'sets completed_at date and returns it as the milestone_date' do
+      expect(step.completed_at).to be_nil
+      step.status = 'completed'
+      step.save
+      expect(step.completed_at).to_not be_nil
+      expect(step.milestone_date).to eq step.created_at.to_time.iso8601
     end
   end
 


### PR DESCRIPTION
## Why was this change made?

Fixes sul-dlss/argo#2192 ... basically because showing `updated_at` dates in argo for milestones is confusing, since those dates are bumped the the lifecycle is no longer active, hiding the dates when the steps were created.

I'm not sure if there are reasons we need to show `updated_at`, but I believe this data is only used for display purposes in Argo.

If we use a new `completed_at` date, this will only be triggered when a workflow step is completed.

## How was this change tested?

New unit tests.

## Which documentation and/or configurations were updated?

None.

