### PR TITLE
Don't do the data migration in the db migration

### DIFF
--- a/db/migrate/20200811212454_workflow_step_completed_at.rb
+++ b/db/migrate/20200811212454_workflow_step_completed_at.rb
@@ -4,9 +4,10 @@ class WorkflowStepCompletedAt < ActiveRecord::Migration[6.0]
   def change
     add_column :workflow_steps, :completed_at, :datetime, null: true
 
+    # This is too slow. We will do it manually, not at deploy time.
     # defaults all completed current rows to set the completed_at to the last time they were updated, new rows will be set accordingly
-    reversible do |dir|
-      dir.up { WorkflowStep.complete.update_all('completed_at = updated_at') }
-    end
+    # reversible do |dir|
+    #   dir.up { WorkflowStep.complete.update_all('completed_at = updated_at') }
+    # end
   end
 end


### PR DESCRIPTION
I will do it in the console (in a screen session) 

## Why was this change made?
the migration takes too long to do in a deploy.  It took 3:30 on stage, and will probably be many times longer in prod.



## How was this change tested?


## Which documentation and/or configurations were updated?



