### PR TITLE
pin rails 6 to minor patch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-gem 'rails', '~> 6.0'
+gem 'rails', '~> 6.1.0'
 
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'config', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -353,7 +353,7 @@ DEPENDENCIES
   pg
   pry-rails
   puma (~> 3.12)
-  rails (~> 6.0)
+  rails (~> 6.1.0)
   resque (~> 2.0)
   rspec-rails (= 4.0.0.beta4)
   rspec_junit_formatter


### PR DESCRIPTION
## Why was this change made?

Because rails tends to break things even in minor updates

## How was this change tested?

Unit tests


## Which documentation and/or configurations were updated?



