### PR TITLE
Add a lock around enquing so multiple processes don't enqueue the same step

### DIFF
--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -21,8 +21,7 @@ class StepsController < ApplicationController
     step.update(parser.to_h)
 
     # Enqueue next steps
-    next_steps = NextStepService.for(step: step)
-    next_steps.each { |next_step| QueueService.enqueue(next_step) }
+    next_steps = NextStepService.enqueue_next_steps(step: step)
 
     SendUpdateMessage.publish(step: step)
     render json: { next_steps: next_steps }

--- a/app/services/queue_service.rb
+++ b/app/services/queue_service.rb
@@ -3,6 +3,7 @@
 # Service for add workflow steps to Resqueue queues
 class QueueService
   # Enqueue the provided step
+  # NOTE: This should only be called by one process at a time. Wrap this in a database row lock.
   # @param [WorkflowStep] workflow step to enqueue
   def self.enqueue(step)
     QueueService.new(step).enqueue
@@ -16,6 +17,7 @@ class QueueService
   end
 
   # Enqueue the provided step
+  # NOTE: This should only be called by one process at a time. Wrap this in a database row lock.
   def enqueue
     # Update status
     step.update(status: 'queued')

--- a/app/services/sweeper.rb
+++ b/app/services/sweeper.rb
@@ -43,6 +43,6 @@ class Sweeper
   end
 
   def enqueue_next_steps(step)
-    NextStepService.for(step: step).each { |next_step| QueueService.enqueue(next_step) }
+    NextStepService.enqueue_next_steps(step: step)
   end
 end

--- a/app/services/workflow_creator.rb
+++ b/app/services/workflow_creator.rb
@@ -42,8 +42,8 @@ class WorkflowCreator
                                       process: processes.first.process)
 
     # Enqueue next steps
-    next_steps = NextStepService.for(step: first_step)
-    next_steps.each { |next_step| QueueService.enqueue(next_step) }
+    NextStepService.enqueue_next_steps(step: first_step)
+
     SendUpdateMessage.publish(step: first_step)
   end
 

--- a/lib/tasks/workflow.rake
+++ b/lib/tasks/workflow.rake
@@ -16,8 +16,7 @@ namespace :workflow do
     puts("Setting #{args[:process]} to #{args[:status]}")
 
     # Enqueue next steps
-    next_steps = NextStepService.for(step: step)
-    next_steps.each { |next_step| QueueService.enqueue(next_step) }
+    NextStepService.enqueue_next_steps(step: step)
 
     SendUpdateMessage.publish(step: step)
   end

--- a/spec/services/next_step_service_spec.rb
+++ b/spec/services/next_step_service_spec.rb
@@ -3,8 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe NextStepService do
-  describe '.for' do
-    subject(:next_steps) { described_class.for(step: step) }
+  describe '.enqueue_next_steps' do
+    subject(:next_steps) { described_class.enqueue_next_steps(step: step) }
 
     context "when there is a step that isn't complete" do
       let(:step) do
@@ -32,10 +32,12 @@ RSpec.describe NextStepService do
                           version: 1,
                           status: 'waiting',
                           active_version: true)
+        allow(QueueService).to receive(:enqueue)
       end
 
       it 'returns a list of unblocked statuses' do
         expect(next_steps).to eq [ready]
+        expect(QueueService).to have_received(:enqueue).with(ready)
       end
     end
 


### PR DESCRIPTION
## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



