### PR TITLE
Prevent workers from starting before the database is updated

### DIFF
--- a/app/services/queue_service.rb
+++ b/app/services/queue_service.rb
@@ -17,11 +17,7 @@ class QueueService
   end
 
   # Enqueue the provided step
-  # NOTE: This should only be called by one process at a time. Wrap this in a database row lock.
   def enqueue
-    # Update status
-    step.update(status: 'queued')
-
     # .enqueue_to will return false if a pre-queue hook prevented it from queueing.
     # Don't necessarily expect this to occur, but want to prevent from failing silently.
     raise "Enqueueing #{class_name} for #{step.druid} to #{queue_name} failed." unless Resque.enqueue_to(queue_name, class_name, step.druid)

--- a/spec/services/queue_service_spec.rb
+++ b/spec/services/queue_service_spec.rb
@@ -15,33 +15,30 @@ RSpec.describe QueueService do
     context 'for JP2 robot (special case)' do
       let(:step) { FactoryBot.create(:workflow_step, workflow: 'assemblyWF', process: 'jp2-create') }
 
-      it 'enqueues to Resque and updates status' do
+      it 'enqueues to Resque' do
         service.enqueue
         expect(Resque).to have_received(:enqueue_to).with('assemblyWF_jp2',
                                                           'Robots::DorRepo::Assembly::Jp2Create', step.druid)
-        expect(step.status).to eq('queued')
       end
     end
 
     context 'for DorRepo classes' do
       let(:step) { FactoryBot.create(:workflow_step, workflow: 'accessionWF', process: 'descriptive-metadata') }
 
-      it 'enqueues to Resque and updates status' do
+      it 'enqueues to Resque' do
         service.enqueue
         expect(Resque).to have_received(:enqueue_to).with('accessionWF_default',
                                                           'Robots::DorRepo::Accession::DescriptiveMetadata', step.druid)
-        expect(step.status).to eq('queued')
       end
     end
 
     context 'for SdrRepo classes' do
       let(:step) { FactoryBot.create(:workflow_step, workflow: 'preservationIngestWF', process: 'transfer-object') }
 
-      it 'enqueues to Resque and updates status' do
+      it 'enqueues to Resque' do
         service.enqueue
         expect(Resque).to have_received(:enqueue_to).with('preservationIngestWF_default',
                                                           'Robots::SdrRepo::PreservationIngest::TransferObject', step.druid)
-        expect(step.status).to eq('queued')
       end
     end
 


### PR DESCRIPTION

## Why was this change made?
We've seen a number of workers get started on processes and then quit because the status was 'waiting' rather than the expected 'queued'. This may happen if the transaction takes a while to resolve

Ref https://app.honeybadger.io/projects/52894/faults/62405703


## How was this change tested?



## Which documentation and/or configurations were updated?



