### PR TITLE
When querying for workflow steps query by workflow

### DIFF
--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -21,8 +21,7 @@ class VersionsController < ApplicationController
   def find_versioning_steps
     obj = Version.new(druid: params[:druid],
                       version: params[:version])
-    obj.workflow_steps.where(
-      workflow: 'versioningWF',
+    obj.workflow_steps('versioningWF').where(
       process: %w[submit-version start-accession]
     )
   end

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -54,7 +54,7 @@ class WorkflowsController < ApplicationController
       druid: params[:druid],
       version: params[:version]
     )
-    obj.workflow_steps.where(workflow: params[:workflow]).destroy_all
+    obj.workflow_steps(params[:workflow]).destroy_all
     head :no_content
   end
 

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -11,7 +11,7 @@ class Version
   attr_reader :druid, :version_id
 
   # @return [ActiveRecord::Relationship] an ActiveRecord scope that has the WorkflowSteps for this version
-  def workflow_steps
-    WorkflowStep.where(druid: druid, version: version_id)
+  def workflow_steps(workflow)
+    WorkflowStep.where(druid: druid, version: version_id, workflow: workflow)
   end
 end

--- a/app/services/next_step_service.rb
+++ b/app/services/next_step_service.rb
@@ -24,7 +24,7 @@ class NextStepService
   # @param [WorkflowStep] step
   # @return [ActiveRecord::Relation] a list of WorkflowSteps
   def find_next(step:) # rubocop:disable Metrics/AbcSize
-    steps = Version.new(druid: step.druid, version: step.version).workflow_steps
+    steps = Version.new(druid: step.druid, version: step.version).workflow_steps(step.workflow)
 
     completed_steps = steps.complete.pluck(:process)
 

--- a/app/services/workflow_creator.rb
+++ b/app/services/workflow_creator.rb
@@ -20,7 +20,7 @@ class WorkflowCreator
   # @return [Array]
   def create_workflow_steps
     ActiveRecord::Base.transaction do
-      version.workflow_steps.where(workflow: workflow_id).destroy_all
+      version.workflow_steps(workflow_id).destroy_all
 
       # Any steps for this object/workflow that are not the current version are marked as not active.
       WorkflowStep.where(workflow: workflow_id, druid: version.druid).update(active_version: false)


### PR DESCRIPTION

## Why was this change made?

This causes the database to use an existing index and dramatically improves performance

Before:

```
[12] pry(main)> steps.waiting.explain
=> EXPLAIN for: SELECT "workflow_steps".* FROM "workflow_steps" WHERE "workflow_steps"."druid" = $1 AND "workflow_steps"."version" = $2 AND "workflow_steps"."status" = $3 [["druid", "druid:bw224zk5025"], ["version", 1], ["status", "waiting"]]
                                                       QUERY PLAN
------------------------------------------------------------------------------------------------------------------------
 Bitmap Heap Scan on workflow_steps  (cost=1692.87..1696.89 rows=1 width=225)
   Recheck Cond: (((druid)::text = 'druid:bw224zk5025'::text) AND (version = 1) AND ((status)::text = 'waiting'::text))
   ->  BitmapAnd  (cost=1692.87..1692.87 rows=1 width=0)
         ->  Bitmap Index Scan on index_workflow_steps_on_druid_and_version  (cost=0.00..21.04 rows=447 width=0)
               Index Cond: (((druid)::text = 'druid:bw224zk5025'::text) AND (version = 1))
         ->  Bitmap Index Scan on step_name_workflow2_idx  (cost=0.00..1671.58 rows=27051 width=0)
               Index Cond: ((status)::text = 'waiting'::text)
(7 rows)
```

After:
```
[14] pry(main)> steps.where(workflow: step.workflow).waiting.explain
=> EXPLAIN for: SELECT "workflow_steps".* FROM "workflow_steps" WHERE "workflow_steps"."druid" = $1 AND "workflow_steps"."version" = $2 AND "workflow_steps"."workflow" = $3 AND "workflow_steps"."status" = $4 [["druid", "druid:bw224zk5025"], ["version", 1], ["workflow", "registrationWF"], ["status", "waiting"]]
                                                                     QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------------
 Index Scan using step_name_with_druid_workflow2_idx on workflow_steps  (cost=0.70..36.55 rows=1 width=225)
   Index Cond: (((status)::text = 'waiting'::text) AND ((workflow)::text = 'registrationWF'::text) AND ((druid)::text = 'druid:bw224zk5025'::text))
   Filter: (version = 1)
(3 rows)
```

Fixes #484

## How was this change tested?



## Which documentation and/or configurations were updated?



