### PR TITLE
Update listen gem for Ruby 3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,11 +4,11 @@ executors:
     environment:
       IMAGE_NAME: suldlss/workflow-server
     docker:
-    - image: circleci/buildpack-deps:stretch
+    - image: cimg/buildpack-deps:stretch
 jobs:
   test:
     docker:
-    - image: circleci/ruby:2.7.1-node
+    - image: cimg/ruby:3.0.3-node
       environment:
         BUNDLE_JOBS: 3
         BUNDLE_RETRY: 3

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ group :development do
   gem 'capistrano-passenger', require: false
   gem 'capistrano-rails', require: false
   gem 'dlss-capistrano', require: false
-  gem 'listen'
+  gem 'listen', '~> 3.7'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ group :development do
   gem 'capistrano-passenger', require: false
   gem 'capistrano-rails', require: false
   gem 'dlss-capistrano', require: false
-  gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'listen'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,10 +191,6 @@ GEM
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
-    nokogiri (1.12.5-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.12.5-x86_64-linux)
-      racc (~> 1.4)
     okcomputer (1.18.4)
     parallel (1.21.0)
     parser (3.0.3.2)
@@ -351,7 +347,7 @@ DEPENDENCIES
   factory_bot_rails
   honeybadger (~> 4.1)
   jbuilder (~> 2.5)
-  listen
+  listen (~> 3.7)
   lograge
   okcomputer
   pg

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,10 +161,9 @@ GEM
     jbuilder (2.11.4)
       activesupport (>= 5.0.0)
     json (2.6.1)
-    listen (3.1.5)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-      ruby_dep (~> 1.2)
+    listen (3.7.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     lograge (0.11.2)
       actionpack (>= 4)
       activesupport (>= 4)
@@ -291,7 +290,6 @@ GEM
       parser (>= 3.0.1.1)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
-    ruby_dep (1.5.0)
     set (1.0.2)
     simplecov (0.17.1)
       docile (~> 1.1)
@@ -353,7 +351,7 @@ DEPENDENCIES
   factory_bot_rails
   honeybadger (~> 4.1)
   jbuilder (~> 2.5)
-  listen (>= 3.0.5, < 3.2)
+  listen
   lograge
   okcomputer
   pg
@@ -371,4 +369,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   2.2.27
+   2.3.4


### PR DESCRIPTION
## Why was this change made?
Ruby 3.0 techstack upgrades


## How was this change tested?
CircleCI and deployed to qa VM with ruby-3.0.3


## Which documentation and/or configurations were updated?



