### PR TITLE
Gemfile: simplecov no longer needs version restriction

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,8 +29,7 @@ group :development, :test do
   gem 'rubocop', '~> 1.0'
   gem 'rubocop-rails'
   gem 'rubocop-rspec'
-  # Codeclimate is not compatible with 0.18+. See https://github.com/codeclimate/test-reporter/issues/413
-  gem 'simplecov', '~> 0.17.1'
+  gem 'simplecov'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,7 +160,6 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.4)
       activesupport (>= 5.0.0)
-    json (2.6.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -299,11 +298,12 @@ GEM
     ruby2_keywords (0.0.5)
     ruby_dep (1.5.0)
     set (1.0.2)
-    simplecov (0.17.1)
+    simplecov (0.21.2)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.3)
     sinatra (2.1.0)
       mustermann (~> 1.0)
       rack (~> 2.2)
@@ -372,7 +372,7 @@ DEPENDENCIES
   rubocop (~> 1.0)
   rubocop-rails
   rubocop-rspec
-  simplecov (~> 0.17.1)
+  simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
   stomp (~> 1.4)


### PR DESCRIPTION
## Why was this change made?

simpler Gemfile, simpler maint.

## How was this change tested?



## Which documentation and/or configurations were updated?



