### PR TITLE
Restoring circleci image.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ executors:
     environment:
       IMAGE_NAME: suldlss/workflow-server
     docker:
-    - image: cimg/base
+    - image: circleci/buildpack-deps:stretch
 jobs:
   test:
     docker:


### PR DESCRIPTION
## Why was this change made?

Fixing the docker image build, since CircleCI failing with cimg/base. Reverting to circleci/buildpack-deps:stretch

## How was this change tested?



## Which documentation and/or configurations were updated?



