### PR TITLE
Silence Redis deprecations to avoid filling up disks with useless logging

### DIFF
--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
+# NOTE: We silence Redis deprecations to avoid filling up disks with logging
+# related to deprecated Redis usage in the Resque gem:
+# https://github.com/resque/resque/issues/1794. If this issue is ever resolved
+# in Resque and we upgrade to a version of Resque with the fix in it, we can
+# roll this back.
+Redis.silence_deprecations = true
+
 # Load Resque configuration and controller
 redis = Redis.new(host: Settings.redis.hostname,
                   port: Settings.redis.port,


### PR DESCRIPTION
## Why was this change made? 🤔

See above

## How was this change tested? 🤨

CI
