### PR TITLE
Removed unnecessary steps from wasCrawlPreassemblyWF

### DIFF
--- a/config/workflows/wasCrawlPreassemblyWF.xml
+++ b/config/workflows/wasCrawlPreassemblyWF.xml
@@ -7,24 +7,8 @@
     <prereq>start</prereq>
     <label>Build druid-tree and copy the files</label>
   </process>
-  <process name="metadata-extractor" sequence="3">
+  <process name="end-was-crawl-preassembly" sequence="3">
     <prereq>build-was-crawl-druid-tree</prereq>
-    <label>Extract metadata from (W)ARCs files</label>
-  </process>
-  <process name="content-metadata-generator" sequence="4">
-    <prereq>metadata-extractor</prereq>
-    <label>Generate content metadata</label>
-  </process>
-  <process name="technical-metadata-generator" sequence="5">
-    <prereq>content-metadata-generator</prereq>
-    <label>Generate technical metadata</label>
-  </process>
-  <process name="desc-metadata-generator" sequence="6">
-    <prereq>technical-metadata-generator</prereq>
-    <label>Generate desc metadata</label>
-  </process>
-  <process name="end-was-crawl-preassembly" sequence="7">
-    <prereq>desc-metadata-generator</prereq>
     <label>End of the WAS Crawl preassembly</label>
   </process>
 </workflow-def>


### PR DESCRIPTION
## Why was this change made? 🤔
These steps are now handled as part of registration.


## How was this change tested? 🤨

⚡ ⚠ If this change affects consumers, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** that exercise this service and/or test in [stage|qa] environment, in addition to specs. ⚡

stage

refs https://github.com/sul-dlss/was-registrar-app/issues/445
refs https://github.com/sul-dlss/was-registrar-app/issues/440

