### PR TITLE
Add an endpoint for doing destroy without providing the repository

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
     delete 'workflows', to: 'steps#destroy_all'
     post 'versionClose', to: 'versions#close'
 
-    resources :workflows, only: %i[show index], param: :workflow do
+    resources :workflows, only: %i[show index destroy], param: :workflow do
       collection do
         post ':workflow', to: 'workflows#create'
         put ':workflow/:process', to: 'steps#update'

--- a/spec/requests/workflows/destroy_workflow_spec.rb
+++ b/spec/requests/workflows/destroy_workflow_spec.rb
@@ -6,8 +6,17 @@ RSpec.describe 'Destroy a workflow' do
   let(:wf) { FactoryBot.create(:workflow_step) }
   let(:druid) { wf.druid }
 
-  it 'deletes workflows' do
-    delete "/dor/objects/#{druid}/workflows/#{wf.workflow}?version=1"
-    expect(response).to be_no_content
+  context 'with repo (deprecated)' do
+    it 'deletes workflows' do
+      delete "/dor/objects/#{druid}/workflows/#{wf.workflow}?version=1"
+      expect(response).to be_no_content
+    end
+  end
+
+  context 'without repo' do
+    it 'deletes workflows' do
+      delete "/objects/#{druid}/workflows/#{wf.workflow}?version=1"
+      expect(response).to be_no_content
+    end
   end
 end


### PR DESCRIPTION


## Why was this change made? 🤔

This is consistent with all the other non-deprecated routes.  This will allow us to remove the `/dor/` URL prefix

## How was this change tested? 🤨
Test suite