### PR TITLE
Remove the unnecessary sequence parameter

### DIFF
--- a/config/workflows/accessionWF.xml
+++ b/config/workflows/accessionWF.xml
@@ -1,46 +1,46 @@
 <?xml version="1.0"?>
 <workflow-def id="accessionWF">
-  <process lifecycle="submitted" name="start-accession" sequence="1" status="completed">
+  <process lifecycle="submitted" name="start-accession" status="completed">
     <label>Start Accessioning</label>
   </process>
-  <process batch-limit="1000" error-limit="10" lifecycle="described" name="descriptive-metadata" sequence="2">
+  <process batch-limit="1000" error-limit="10" lifecycle="described" name="descriptive-metadata">
     <label>Any descMetadata.xml is converted and posted to cocina object; no-op if no such file exists (cocina object may already have information)</label>
     <prereq>start-accession</prereq>
   </process>
-  <process batch-limit="1000" error-limit="10" name="content-metadata" sequence="3">
+  <process batch-limit="1000" error-limit="10" name="content-metadata">
     <label>Any contentMetadata.xml is converted and posted to cocina object; no-op if no such file exists (cocina object may already have information)</label>
     <prereq>descriptive-metadata</prereq>
   </process>
-  <process batch-limit="1000" error-limit="10" name="technical-metadata" sequence="4">
+  <process batch-limit="1000" error-limit="10" name="technical-metadata">
     <label>Creates the technical metadata by calling technical-metadata-service, only for item objects with files</label>
     <prereq>content-metadata</prereq>
   </process>
-  <process batch-limit="1" error-limit="5" name="shelve" sequence="5">
+  <process batch-limit="1" error-limit="5" name="shelve">
     <label>Shelve content in Digital Stacks</label>
     <prereq>technical-metadata</prereq>
   </process>
-  <process batch-limit="100" error-limit="10" lifecycle="published" name="publish" sequence="6">
+  <process batch-limit="100" error-limit="10" lifecycle="published" name="publish">
     <label>Sends metadata to PURL (but it may be updated by releaseWF)</label>
     <prereq>shelve</prereq>
   </process>
-  <process batch-limit="100" error-limit="10" name="update-doi" sequence="7">
+  <process batch-limit="100" error-limit="10" name="update-doi">
     <label>Update DOI Metadata</label>
     <prereq>publish</prereq>
   </process>
-  <process batch-limit="1" error-limit="5" name="sdr-ingest-transfer" sequence="8">
+  <process batch-limit="1" error-limit="5" name="sdr-ingest-transfer">
     <label>Initiate Ingest into Preservation</label>
     <prereq>publish</prereq>
   </process>
-  <process batch-limit="1" error-limit="5" lifecycle="deposited" name="sdr-ingest-received" sequence="9" skip-queue="true">
+  <process batch-limit="1" error-limit="5" lifecycle="deposited" name="sdr-ingest-received" skip-queue="true">
     <label>Signal from SDR that object has been received</label>
   </process>
-  <process batch-limit="1" error-limit="5" name="reset-workspace" sequence="10">
+  <process batch-limit="1" error-limit="5" name="reset-workspace">
     <label>Reset workspace by renaming the druid-tree to a versioned directory</label>
     <prereq>sdr-ingest-received</prereq>
     <prereq>publish</prereq>
     <prereq>shelve</prereq>
   </process>
-  <process batch-limit="1" error-limit="5" lifecycle="accessioned" name="end-accession" sequence="11">
+  <process batch-limit="1" error-limit="5" lifecycle="accessioned" name="end-accession">
     <label>Clean up any diff caches and set disseminationWF:cleanup to waiting</label>
     <prereq>update-doi</prereq>
     <prereq>reset-workspace</prereq>

--- a/config/workflows/assemblyWF.xml
+++ b/config/workflows/assemblyWF.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0"?>
 <workflow-def id="assemblyWF">
-  <process name="start-assembly" sequence="1" status="completed">
+  <process name="start-assembly" status="completed">
     <label>Initiate assembly of the object</label>
   </process>
-  <process name="content-metadata-create" sequence="2">
+  <process name="content-metadata-create">
     <prereq>start-assembly</prereq>
     <label>Create contentMetadata.xml from stub (from Goobi) if it exists; any contentMetadata.xml is converted and posted to cocina object</label>
   </process>
-  <process name="jp2-create" sequence="3">
+  <process name="jp2-create">
     <prereq>content-metadata-create</prereq>
     <label>Create JP2 derivatives for images in object</label>
   </process>
-  <process name="checksum-compute" sequence="4">
+  <process name="checksum-compute">
     <prereq>jp2-create</prereq>
     <label>Compute and compare checksums for any files referenced in cocina</label>
   </process>
-  <process name="exif-collect" sequence="5">
+  <process name="exif-collect">
     <prereq>checksum-compute</prereq>
     <label>Calculate and add exif, mimetype, file size and other attributes to each file in cocina</label>
   </process>
-  <process name="accessioning-initiate" sequence="6">
+  <process name="accessioning-initiate">
     <prereq>exif-collect</prereq>
     <label>Initiate workspace and start common accessioning</label>
   </process>

--- a/config/workflows/digitizationWF.xml
+++ b/config/workflows/digitizationWF.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <workflow-def id="digitizationWF">
-  <process lifecycle="registered" name="initiate" sequence="1" status="completed">
+  <process lifecycle="registered" name="initiate" status="completed">
     <label>Initiate digitization workflow</label>
   </process>
-  <process lifecycle="digitized" name="digitize" sequence="2">
+  <process lifecycle="digitized" name="digitize">
     <prereq>initiate</prereq>
     <label>Place-holder step for digitization processes</label>
   </process>
-  <process name="start-accession" sequence="3">
+  <process name="start-accession">
     <prereq>digitize</prereq>
     <label>Start accessioning</label>
   </process>

--- a/config/workflows/disseminationWF.xml
+++ b/config/workflows/disseminationWF.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <workflow-def id="disseminationWF">
-  <process name="cleanup" sequence="1" status="waiting">
+  <process name="cleanup" status="waiting">
     <label>IClean up DOR workspace after accessioning</label>
   </process>
 </workflow-def>

--- a/config/workflows/dpgImageWF.xml
+++ b/config/workflows/dpgImageWF.xml
@@ -1,50 +1,50 @@
 <?xml version="1.0"?>
 
 <workflow-def id="dpgImageWF" repository="dor">
-  <process lifecycle="registered" name="initiate" sequence="1" status="completed">
+  <process lifecycle="registered" name="initiate" status="completed">
     <label>Object Registered</label>
   </process>
-  <process name="tracking_db" sequence="2" status="waiting">
+  <process name="tracking_db" status="waiting">
     <label>Add to DPG tracking database</label>
     <prereq>initiate</prereq>
   </process>
-  <process lifecycle="scanned" name="scan" sequence="3" status="waiting">
+  <process lifecycle="scanned" name="scan" status="waiting">
     <label>Scan</label>
     <prereq>tracking_db</prereq>
   </process>
-  <process name="completeness" sequence="4" status="waiting">
+  <process name="completeness" status="waiting">
     <label>Completeness Check</label>
     <prereq>scan</prereq>
   </process>
-  <process name="postprocessing" sequence="5" status="waiting">
+  <process name="postprocessing" status="waiting">
     <label>Postprocessing</label>
     <prereq>scan</prereq>
   </process>
-  <process lifecycle="imageqced" name="imageqc" sequence="6" status="waiting">
+  <process lifecycle="imageqced" name="imageqc" status="waiting">
     <label>Image QC</label>
     <prereq>scan</prereq>
   </process>
-  <process lifecycle="imported" name="import_files" sequence="7" status="waiting">
+  <process lifecycle="imported" name="import_files" status="waiting">
     <label>Import Files</label>
     <prereq>imageqc</prereq>
   </process>
-  <process name="md5_gen" sequence="8" status="waiting">
+  <process name="md5_gen" status="waiting">
     <label>Generate MD5 Checksums</label>
     <prereq>import_files</prereq>
   </process>
-  <process name="copy_to_assembly" sequence="9" status="waiting">
+  <process name="copy_to_assembly" status="waiting">
     <label>Transfer to Assembly Workspace</label>
     <prereq>md5_gen</prereq>
   </process>
-  <process name="md5_verify_assembly" sequence="10" status="waiting">
+  <process name="md5_verify_assembly" status="waiting">
     <label>Verify MD5 Checksums</label>
     <prereq>copy_to_assembly</prereq>
   </process>
-  <process name="delete_scratch" sequence="11" status="waiting">
+  <process name="delete_scratch" status="waiting">
     <label>Delete files from DPG scratch space</label>
     <prereq>md5_verify_assembly</prereq>
   </process>
-  <process lifecycle="digitized" name="digitized" sequence="12" status="waiting">
+  <process lifecycle="digitized" name="digitized" status="waiting">
     <label>Digitization Complete</label>
     <prereq>delete_scratch</prereq>
   </process>

--- a/config/workflows/eemsAccessionWF.xml
+++ b/config/workflows/eemsAccessionWF.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0"?>
 <workflow-def id="eemsAccessionWF" repository="dor">
-  <process batch-limit="5" error-limit="5" lifecycle="registered" name="register-object" sequence="1" status="completed">
+  <process batch-limit="5" error-limit="5" lifecycle="registered" name="register-object" status="completed">
     <label>Register new objects in DOR</label>
   </process>
-  <process batch-limit="5" error-limit="5" lifecycle="inprocess" name="submit-tech-services" sequence="2">
+  <process batch-limit="5" error-limit="5" lifecycle="inprocess" name="submit-tech-services">
     <prereq>register-object</prereq>
     <label>Submit to Tech Services</label>
   </process>
-  <process batch-limit="5" error-limit="5" name="eems-transfer" sequence="3">
+  <process batch-limit="5" error-limit="5" name="eems-transfer">
     <prereq>submit-tech-services</prereq>
     <label>Transfer content to workspace</label>
   </process>
-  <process batch-limit="100" error-limit="5" name="submit-marc" sequence="4">
+  <process batch-limit="100" error-limit="5" name="submit-marc">
     <prereq>eems-transfer</prereq>
     <label>Send stub MARC record to Symphony</label>
   </process>
-  <process batch-limit="100" error-limit="5" name="check-marc" sequence="5">
+  <process batch-limit="100" error-limit="5" name="check-marc">
     <prereq>submit-marc</prereq>
     <label>Check for creation of MARC record</label>
   </process>
-  <process batch-limit="100" error-limit="5" name="catalog-status" sequence="6">
+  <process batch-limit="100" error-limit="5" name="catalog-status">
     <prereq>check-marc</prereq>
     <label>Monitor status of MARC record for completion</label>
   </process>
-  <process batch-limit="1000" error-limit="10" name="other-metadata" sequence="7">
+  <process batch-limit="1000" error-limit="10" name="other-metadata">
     <prereq>catalog-status</prereq>
     <label>Other metadata</label>
   </process>
-  <process batch-limit="1" error-limit="5" name="start-accession" sequence="8">
+  <process batch-limit="1" error-limit="5" name="start-accession">
     <prereq>other-metadata</prereq>
     <label>Start common-accessioning</label>
   </process>

--- a/config/workflows/etdSubmitWF.xml
+++ b/config/workflows/etdSubmitWF.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0"?>
 <workflow-def id="etdSubmitWF">
-  <process lifecycle="registered" name="register-object" sequence="1" skip-queue="true" status="completed">
+  <process lifecycle="registered" name="register-object" skip-queue="true" status="completed">
     <label>Register object in DOR</label>
   </process>
-  <process name="submit" sequence="2" skip-queue="true">
+  <process name="submit" skip-queue="true">
     <label>Student submits completed ETD</label>
   </process>
-  <process name="reader-approval" sequence="3" skip-queue="true">
+  <process name="reader-approval" skip-queue="true">
     <label>Faculty reader(s) have approved (signal from PeopleSoft)</label>
   </process>
-  <process name="registrar-approval" sequence="4" skip-queue="true">
+  <process name="registrar-approval" skip-queue="true">
     <label>Final Registrar approval (signal from PeopleSoft)</label>
   </process>
-  <process name="submit-marc" sequence="5" skip-queue="true">
+  <process name="submit-marc" skip-queue="true">
     <label>Create stub MARC record for Symphony; daily crons run on etd app to aggregate these records and make them available to Symphony</label>
     <prereq>registrar-approval</prereq>
   </process>
-  <process name="check-marc" sequence="6" skip-queue="true">
+  <process name="check-marc" skip-queue="true">
     <label>Check to see if MARC record has been loaded into Symphony (ILS); if so, updates identityMetadata with ckey and ETD agreement.  Run via cron.</label>
     <prereq>submit-marc</prereq>
   </process>
-  <process name="catalog-status" sequence="7" skip-queue="true">
+  <process name="catalog-status" skip-queue="true">
     <label>Check to see if cataloging is done in Symphony (ILS); run via cron</label>
     <prereq>check-marc</prereq>
   </process>
-  <process name="other-metadata" sequence="8" skip-queue="true">
+  <process name="other-metadata" skip-queue="true">
     <label>Update descMetadata from Symphony, generate content metadata, rights metadata, create a tag.</label>
     <prereq>catalog-status</prereq>
   </process>
-  <process name="start-accession" sequence="9" skip-queue="true">
+  <process name="start-accession" skip-queue="true">
     <label>Transfer control to Common Accessioning</label>
     <prereq>other-metadata</prereq>
   </process>
-  <process name="binder-transfer" sequence="10" skip-queue="true" status="skipped">
+  <process name="binder-transfer" skip-queue="true" status="skipped">
     <label>No longer used.  (Transfer PDF to binder drop off directory for bound physical copy)</label>
   </process>
 </workflow-def>

--- a/config/workflows/gisAssemblyWF.xml
+++ b/config/workflows/gisAssemblyWF.xml
@@ -1,69 +1,69 @@
 <?xml version="1.0"?>
 <workflow-def id="gisAssemblyWF">
-  <process name="start-gis-assembly-workflow" sequence="1" status="completed">
+  <process name="start-gis-assembly-workflow" status="completed">
     <label>Initiate assembly workflow for the object</label>
   </process>
-  <process name="register-druid" sequence="2" status="completed">
+  <process name="register-druid" status="completed">
     <prereq>start-gis-assembly-workflow</prereq>
     <label>Ensure proper registration of druid, source ID, and label</label>
   </process>
-  <process name="author-metadata" sequence="3">
+  <process name="author-metadata">
     <prereq>register-druid</prereq>
     <label>Author metadata using ArcCatalog</label>
   </process>
-  <process name="extract-thumbnail" sequence="4">
+  <process name="extract-thumbnail">
     <prereq>author-metadata</prereq>
     <label>Extract thumbnail preview from ArcCatalog metadata</label>
   </process>
-  <process name="extract-iso19139" sequence="5">
+  <process name="extract-iso19139">
     <prereq>extract-thumbnail</prereq>
     <label>Transform ISO 19139 metadata from ArcCatalog metadata</label>
   </process>
-  <process name="generate-geo-metadata" sequence="6">
+  <process name="generate-geo-metadata">
     <prereq>extract-iso19139</prereq>
     <label>Convert ISO 19139 metadata into geoMetadata RDF XML file</label>
   </process>
-  <process name="generate-mods" sequence="7">
+  <process name="generate-mods">
     <prereq>generate-geo-metadata</prereq>
     <label>Convert geoMetadata into MODS</label>
   </process>
-  <process name="assign-placenames" sequence="8">
+  <process name="assign-placenames">
     <prereq>generate-mods</prereq>
     <label>Insert linked data into MODS record from gazetteer</label>
   </process>
-  <process name="finish-metadata" sequence="9">
+  <process name="finish-metadata">
     <prereq>assign-placenames</prereq>
     <label>Finalize the metadata preparation</label>
   </process>
-  <process name="wrangle-data" sequence="10">
+  <process name="wrangle-data">
     <prereq>finish-metadata</prereq>
     <label>Wrangle the data into the digital work</label>
   </process>
-  <process name="package-data" sequence="11">
+  <process name="package-data">
     <prereq>wrangle-data</prereq>
     <label>Package the digital work</label>
   </process>
-  <process name="normalize-data" sequence="12">
+  <process name="normalize-data">
     <prereq>package-data</prereq>
     <label>Reproject the data into common SRS projection and/or file format</label>
   </process>
-  <process name="extract-boundingbox" sequence="13">
+  <process name="extract-boundingbox">
     <prereq>normalize-data</prereq>
     <label>Extract bounding box from data for MODS record</label>
   </process>
-  <process name="finish-data" sequence="14">
+  <process name="finish-data">
     <prereq>extract-boundingbox</prereq>
     <label>Finalize the data preparation</label>
   </process>
-  <process name="generate-content-metadata" sequence="15">
+  <process name="generate-content-metadata">
     <prereq>finish-data</prereq>
     <label>Generate contentMetadata manifest</label>
   </process>
-  <process name="load-geo-metadata" sequence="16">
+  <process name="load-geo-metadata">
     <prereq>generate-content-metadata</prereq>
     <label>Accession geoMetadata RDF XML file into SDR</label>
   </process>
-  <process name="finish-gis-assembly-workflow" sequence="17">
+  <process name="finish-gis-assembly-workflow">
     <prereq>load-geo-metadata</prereq>
     <label>Finalize assembly workflow to prepare for assembly/delivery/discovery</label>
   </process>

--- a/config/workflows/gisDeliveryWF.xml
+++ b/config/workflows/gisDeliveryWF.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0"?>
 <workflow-def id="gisDeliveryWF">
-  <process name="start-gis-delivery-workflow" sequence="1" status="completed">
+  <process name="start-gis-delivery-workflow" status="completed">
     <label>Initiate delivery workflow for the object</label>
   </process>
-  <process name="load-vector" sequence="2">
+  <process name="load-vector">
     <prereq>start-gis-delivery-workflow</prereq>
     <label>Load vector data into PostGIS database</label>
   </process>
-  <process name="load-raster" sequence="3">
+  <process name="load-raster">
     <prereq>load-vector</prereq>
     <label>Load raster into GeoTIFF data store</label>
   </process>
-  <process name="load-geoserver" sequence="4">
+  <process name="load-geoserver">
     <prereq>load-raster</prereq>
     <label>Load layers into GeoServer</label>
   </process>
-  <process name="reset-geowebcache" sequence="5">
+  <process name="reset-geowebcache">
     <prereq>reset-geowebcache</prereq>
     <label>Reset GeoWebCache for the layer</label>
   </process>
-  <process name="finish-gis-delivery-workflow" sequence="6">
+  <process name="finish-gis-delivery-workflow">
     <prereq>load-geoserver</prereq>
     <label>Finalize delivery workflow for the object</label>
   </process>

--- a/config/workflows/gisDiscoveryWF.xml
+++ b/config/workflows/gisDiscoveryWF.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0"?>
 <workflow-def id="gisDiscoveryWF">
-  <process name="start-gis-discovery-workflow" sequence="1" status="completed">
+  <process name="start-gis-discovery-workflow" status="completed">
     <label>Initiate GIS discovery workflow for the object</label>
   </process>
-  <process name="generate-geoblacklight" sequence="2">
+  <process name="generate-geoblacklight">
     <prereq>start-gis-discovery-workflow</prereq>
     <label>Generate Solr document for GeoBlacklight schema</label>
   </process>
-  <process name="load-geoblacklight" sequence="3">
+  <process name="load-geoblacklight">
     <prereq>generate-geoblacklight</prereq>
     <label>Load Solr document into GeoBlacklight Solr index</label>
   </process>
-  <process name="export-opengeometadata" sequence="4">
+  <process name="export-opengeometadata">
     <prereq>load-geoblacklight</prereq>
     <label>Export metadata files for import into OpenGeoMetadata repository</label>
   </process>
-  <process name="finish-gis-discovery-workflow" sequence="5">
+  <process name="finish-gis-discovery-workflow">
     <prereq>export-opengeometadata</prereq>
     <label>Finalize GIS discovery workflow for the object</label>
   </process>

--- a/config/workflows/goobiWF.xml
+++ b/config/workflows/goobiWF.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <workflow-def id="goobiWF">
-  <process lifecycle="registered" name="register" sequence="1" status="completed">
+  <process lifecycle="registered" name="register" status="completed">
     <label>Register an object</label>
   </process>
-  <process name="start" sequence="2" skip-queue="true" status="completed">
+  <process name="start" skip-queue="true" status="completed">
     <label>Initiate goobi workflow for the object</label>
   </process>
-  <process name="goobi-notify" sequence="3">
+  <process name="goobi-notify">
     <prereq>start</prereq>
     <label>Notify goobi of object registration</label>
   </process>

--- a/config/workflows/googleScannedBookWF.xml
+++ b/config/workflows/googleScannedBookWF.xml
@@ -1,42 +1,42 @@
 <?xml version="1.0"?>
 <workflow-def id="googleScannedBookWF" repository="dor">
-  <process batch-limit="1000" lifecycle="inprocess" name="register-object" sequence="1">
+  <process batch-limit="1000" lifecycle="inprocess" name="register-object">
     <label>Register new objects in DOR</label>
   </process>
-  <process batch-limit="1000" name="descriptive-metadata" sequence="2">
+  <process batch-limit="1000" name="descriptive-metadata">
     <prereq>register-object</prereq>
     <label>Make descriptive metadata (MODS &amp; DC) from Symphony/MARC</label>
   </process>
-  <process batch-limit="10" name="google-convert" sequence="3">
+  <process batch-limit="10" name="google-convert">
     <prereq>register-object</prereq>
     <label>Request GRIN items to be converted for download</label>
   </process>
-  <process batch-limit="300" name="google-download" sequence="4">
+  <process batch-limit="300" name="google-download">
     <prereq>descriptive-metadata</prereq>
     <label>Download content from Google</label>
   </process>
-  <process batch-limit="1000" name="process-content" sequence="5">
+  <process batch-limit="1000" name="process-content">
     <prereq>google-download</prereq>
     <label>Process content, create tech/rights/provenance/content metadata</label>
   </process>
-  <process batch-limit="1000" name="sdr-ingest-transfer" sequence="6">
+  <process batch-limit="1000" name="sdr-ingest-transfer">
     <prereq>process-content</prereq>
     <label>Prepare bagit transfer package, push to SDR-Stage</label>
   </process>
-  <process batch-limit="300" name="sdr-ingest-deposit" sequence="7">
+  <process batch-limit="300" name="sdr-ingest-deposit">
     <prereq>sdr-ingest-transfer</prereq>
     <label>Call from SDR on completed ingest</label>
   </process>
-  <process batch-limit="1000" lifecycle="released" name="shelve" sequence="8">
+  <process batch-limit="1000" lifecycle="released" name="shelve">
     <prereq>process-content</prereq>
     <label>Shelve contents in the Digital Stacks</label>
   </process>
-  <process batch-limit="300" lifecycle="accessioned" name="cleanup" sequence="9">
+  <process batch-limit="300" lifecycle="accessioned" name="cleanup">
     <prereq>sdr-ingest-deposit</prereq>
     <prereq>shelve</prereq>
     <label>Cleanup workspace; make room for more</label>
   </process>
-  <process batch-limit="300" lifecycle="archived" name="sdr-ingest-archive" sequence="10">
+  <process batch-limit="300" lifecycle="archived" name="sdr-ingest-archive">
     <prereq>sdr-ingest-transfer</prereq>
     <label>Call from SDR on completed archiving</label>
   </process>

--- a/config/workflows/hydrusAssemblyWF.xml
+++ b/config/workflows/hydrusAssemblyWF.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0"?>
 <workflow-def id="hydrusAssemblyWF">
-  <process lifecycle="registered" name="start-deposit" sequence="1" status="completed" skip-queue="true">
+  <process lifecycle="registered" name="start-deposit" status="completed" skip-queue="true">
     <label>Initiate assembly of the hydrus object</label>
   </process>
-  <process name="submit" sequence="2" skip-queue="true">
+  <process name="submit" skip-queue="true">
     <prereq>start-deposit</prereq>
     <label>Start hydrus deposit</label>
   </process>
-  <process name="approve" sequence="3" skip-queue="true">
+  <process name="approve" skip-queue="true">
     <prereq>submit</prereq>
     <label>Hydrus object approval</label>
   </process>
-  <process name="start-assembly" sequence="4" skip-queue="true">
+  <process name="start-assembly" skip-queue="true">
     <prereq>submit</prereq>
     <label>Start assemblyWF</label>
   </process>

--- a/config/workflows/preservationAuditWF.xml
+++ b/config/workflows/preservationAuditWF.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <workflow-def id="preservationAuditWF">
-  <process name="moab-valid" sequence="1" skip-queue="true">
+  <process name="moab-valid" skip-queue="true">
     <label>Moab validation errors</label>
   </process>
-  <process name="preservation-audit" sequence="2" skip-queue="true">
+  <process name="preservation-audit" skip-queue="true">
     <label>preservation object audit errors</label>
   </process>
 </workflow-def>

--- a/config/workflows/preservationIngestWF.xml
+++ b/config/workflows/preservationIngestWF.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0"?>
 <workflow-def id="preservationIngestWF" repository="sdr">
-  <process name="start-ingest" sequence="1" status="completed">
+  <process name="start-ingest" status="completed">
     <label>Initiate preservation ingest workflow</label>
   </process>
-  <process name="transfer-object" sequence="2">
+  <process name="transfer-object">
     <label>Get bagit/Moab deposit bag for new Moab version from (common-accessioning sdrIngestTransfer robot)</label>
     <prereq>start-ingest</prereq>
   </process>
-  <process name="validate-bag" sequence="3">
+  <process name="validate-bag">
     <label>Verify the bagit/Moab deposit bag structure of new version</label>
     <prereq>transfer-object</prereq>
   </process>
-  <process name="update-moab" sequence="4">
+  <process name="update-moab">
     <label>Create/update Moab object from deposit bag</label>
     <prereq>validate-bag</prereq>
   </process>
-  <process name="validate-moab" sequence="5">
+  <process name="validate-moab">
     <label>Verify the Moab on local disk passes validation, including checksums</label>
     <prereq>update-moab</prereq>
   </process>
-  <process name="update-catalog" sequence="6">
+  <process name="update-catalog">
     <label>Create/update Preservation Catalog entry</label>
     <prereq>validate-moab</prereq>
   </process>
-  <process name="complete-ingest" sequence="7">
+  <process name="complete-ingest">
     <label>Clean up workspace; transfer control back to accessioning</label>
     <prereq>update-catalog</prereq>
   </process>

--- a/config/workflows/registrationWF.xml
+++ b/config/workflows/registrationWF.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <workflow-def id="registrationWF">
-  <process lifecycle="registered" name="register" sequence="1" status="completed">
+  <process lifecycle="registered" name="register" status="completed">
     <label>Register an object</label>
   </process>
 </workflow-def>

--- a/config/workflows/releaseWF.xml
+++ b/config/workflows/releaseWF.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0"?>
 <workflow-def id="releaseWF">
-  <process name="start" sequence="1" skip-queue="true" status="completed">
+  <process name="start" skip-queue="true" status="completed">
     <label>Initiate item release of the object</label>
   </process>
-  <process name="release-members" sequence="2">
+  <process name="release-members">
     <prereq>start</prereq>
     <label>Determine which items to release</label>
   </process>
-  <process name="release-publish" queue-limit="50" sequence="3">
+  <process name="release-publish" queue-limit="50">
     <prereq>release-members</prereq>
     <label>Determines which items to republish</label>
   </process>
-  <process name="update-marc" sequence="4">
+  <process name="update-marc">
     <prereq>release-publish</prereq>
     <label>Generates Symphony record with PURL URI</label>
   </process>

--- a/config/workflows/sdrIngestWF.xml
+++ b/config/workflows/sdrIngestWF.xml
@@ -1,37 +1,37 @@
 <?xml version="1.0"?>
 <workflow-def id="sdrIngestWF" repository="sdr">
-  <process name="start-ingest" sequence="1" status="completed">
+  <process name="start-ingest" status="completed">
     <label>Initiate deposit</label>
   </process>
-  <process name="register-sdr" sequence="2">
+  <process name="register-sdr">
     <label>Verify status of accession workflow</label>
     <prereq>start-ingest</prereq>
   </process>
-  <process name="transfer-object" sequence="3">
+  <process name="transfer-object">
     <label>Transfer contents from DOR</label>
     <prereq>register-sdr</prereq>
   </process>
-  <process name="validate-bag" sequence="4">
+  <process name="validate-bag">
     <label>Verify the bagit bag structure</label>
     <prereq>transfer-object</prereq>
   </process>
-  <process name="verify-agreement" sequence="5">
+  <process name="verify-agreement">
     <label>Verify that the governing APO object has been previously ingested</label>
     <prereq>validate-bag</prereq>
   </process>
-  <process name="complete-deposit" sequence="6">
+  <process name="complete-deposit">
     <label>Store the object on disk in the Moab structure</label>
     <prereq>verify-agreement</prereq>
   </process>
-  <process name="update-catalog" sequence="7" skip-queue="true" status="skipped">
+  <process name="update-catalog" skip-queue="true" status="skipped">
     <label>Insert data in archive catalog for object and version</label>
     <prereq>complete-deposit</prereq>
   </process>
-  <process name="create-replica" sequence="8" skip-queue="true" status="skipped">
+  <process name="create-replica" skip-queue="true" status="skipped">
     <label>Create the replica tarfile</label>
     <prereq>update-catalog</prereq>
   </process>
-  <process name="ingest-cleanup" sequence="9">
+  <process name="ingest-cleanup">
     <label>Clean up workspace, route back to accession workflow</label>
     <prereq>create-replica</prereq>
     <prereq>complete-deposit</prereq>

--- a/config/workflows/versioningWF.xml
+++ b/config/workflows/versioningWF.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <workflow-def id="versioningWF">
-  <process lifecycle="opened" name="start-version" sequence="1" status="completed">
+  <process lifecycle="opened" name="start-version" status="completed">
     <label>Initiate new version of the object</label>
   </process>
-  <process name="submit-version" sequence="2" skip-queue="true">
+  <process name="submit-version" skip-queue="true">
     <prereq>start-version</prereq>
     <label>Assembly complete, submit for review or accessioning</label>
   </process>
-  <process name="start-accession" sequence="3">
+  <process name="start-accession">
     <prereq>review-version</prereq>
     <label>Start accessioning</label>
   </process>

--- a/config/workflows/wasCrawlDisseminationWF.xml
+++ b/config/workflows/wasCrawlDisseminationWF.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0"?>
 <workflow-def id="wasCrawlDisseminationWF">
-  <process name="start" sequence="1" status="completed">
+  <process name="start" status="completed">
     <label>Initiate was crawl disseminationWF of the object</label>
   </process>
-  <process name="warc-extractor" sequence="2">
+  <process name="warc-extractor">
     <prereq>start</prereq>
     <label>Extracts WARC files from WACZ files</label>
   </process>
-  <process name="cdx-generator" sequence="3">
+  <process name="cdx-generator">
     <prereq>warc-extractor</prereq>
     <label>Generate CDX files for (W)ARCs</label>
   </process>
-  <process name="cdx-merge-sort-publish" sequence="4">
+  <process name="cdx-merge-sort-publish">
     <prereq>cdx-generator</prereq>
     <label>Sort individual new CDX files, merge into existing openwayback cdx file</label>
   </process>
-  <process name="path-indexer" sequence="5">
+  <process name="path-indexer">
     <prereq>cdx-merge-sort-publish</prereq>
     <label>Update the path index with the new (W)ARCs</label>
   </process>
-  <process name="cdxj-generator" sequence="6">
+  <process name="cdxj-generator">
     <prereq>path-indexer</prereq>
     <label>Generate CDXJ files for WARCs</label>
   </process>
-  <process name="cdxj-merge" sequence="7">
+  <process name="cdxj-merge">
     <prereq>cdxj-generator</prereq>
     <label>Merge new CDX into existing pywb CDX file</label>
   </process>

--- a/config/workflows/wasCrawlPreassemblyWF.xml
+++ b/config/workflows/wasCrawlPreassemblyWF.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <workflow-def id="wasCrawlPreassemblyWF">
-  <process name="start" sequence="1" status="completed">
+  <process name="start" status="completed">
     <label>Initiate WAS Crawl Preassembly WF of the object</label>
   </process>
-  <process name="build-was-crawl-druid-tree" sequence="2">
+  <process name="build-was-crawl-druid-tree">
     <prereq>start</prereq>
     <label>Build druid-tree and copy the files</label>
   </process>
-  <process name="end-was-crawl-preassembly" sequence="3">
+  <process name="end-was-crawl-preassembly">
     <prereq>build-was-crawl-druid-tree</prereq>
     <label>End of the WAS Crawl preassembly</label>
   </process>

--- a/config/workflows/wasDisseminationWF.xml
+++ b/config/workflows/wasDisseminationWF.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <workflow-def id="wasDisseminationWF">
-  <process name="start" sequence="1" skip-queue="true" status="completed">
+  <process name="start" skip-queue="true" status="completed">
     <label>Initiate was DisseminationWF of the object</label>
   </process>
-  <process name="start-special-dissemination" sequence="2">
+  <process name="start-special-dissemination">
     <prereq>start</prereq>
     <label>Choose the suitable disseminationWF based on the object type</label>
   </process>

--- a/config/workflows/wasSeedDisseminationWF.xml
+++ b/config/workflows/wasSeedDisseminationWF.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <workflow-def id="wasSeedDisseminationWF">
-  <process name="start" sequence="1" skip-queue="true" status="completed">
+  <process name="start" skip-queue="true" status="completed">
     <label>Initiate Sed Dissemination WF of the object</label>
   </process>
-  <process name="update-thumbnail-generator" sequence="2">
+  <process name="update-thumbnail-generator">
     <prereq>start</prereq>
     <label>It sends the druid and uri to thumbnail generator service</label>
   </process>

--- a/config/workflows/wasSeedPreassemblyWF.xml
+++ b/config/workflows/wasSeedPreassemblyWF.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0"?>
 <workflow-def id="wasSeedPreassemblyWF">
-  <process name="start" sequence="1" status="completed">
+  <process name="start" status="completed">
     <label>Initiate WAS Seed Preassembly WF of the object</label>
   </process>
-  <process name="desc-metadata-generator" sequence="2">
+  <process name="desc-metadata-generator">
     <prereq>start</prereq>
     <label>Generate desc metadata</label>
   </process>
-  <process name="thumbnail-generator" sequence="3">
+  <process name="thumbnail-generator">
     <prereq>desc-metadata-generator</prereq>
     <label>Generate thumbnail for the seed URI</label>
   </process>
-  <process name="content-metadata-generator" sequence="4">
+  <process name="content-metadata-generator">
     <prereq>thumbnail-generator</prereq>
     <label>Generate content metadata</label>
   </process>
-  <process name="end-was-seed-preassembly" sequence="5">
+  <process name="end-was-seed-preassembly">
     <prereq>content-metadata-generator</prereq>
     <label>End of the WAS Seed preassembly</label>
   </process>


### PR DESCRIPTION


## Why was this change made? 🤔
The sequence parameter is misleading in that we never use it.  The "next step" to run is all the steps that have their prerequisites met.  This allows the workflow system to follow parallel paths.


## How was this change tested? 🤨

⚡ ⚠ If this change affects consumers, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** that exercise this service and/or test in [stage|qa] environment, in addition to specs. ⚡


