### PR TITLE
update README and specs to reflect absence of repo parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,26 +76,24 @@ To shut down postgres afterwards,
 - ```docker-compose down``` afterwards
 
 ## Routes:
-`GET    /:repo/objects/:druid/lifecycle` - Returns the milestones in the lifecycle that have been completed
-
 `GET    /objects/:druid/lifecycle` - Returns the milestones in the lifecycle that have been completed
 
 
-`POST   /:repo/objects/:druid/versionClose` - Set all versioningWF steps to 'complete' and starts a new accessionWF unless `create-accession=false` is passed as a parameter.
+`POST   /objects/:druid/versionClose` - Set all versioningWF steps to 'complete' and starts a new accessionWF unless `create-accession=false` is passed as a parameter.
 
 
 These methods deal with the workflow for a single object
 ```
 POST   /objects/:druid/workflows/:workflow
-GET    /:repo/objects/:druid/workflows
-GET    /:repo/objects/:druid/workflows/:workflow
-DELETE /:repo/objects/:druid/workflows/:workflow
+GET    /objects/:druid/workflows
+GET    /objects/:druid/workflows/:workflow
+DELETE /objects/:druid/workflows/:workflow
 ```
 
 These methods deal with a single step for a single object
 ```
-PUT    /:repo/objects/:druid/workflows/:workflow/:process
-GET    /:repo/objects/:druid/workflows/:workflow/:process
+PUT    /objects/:druid/workflows/:workflow/:process
+GET    /objects/:druid/workflows/:workflow/:process
 ```
 
 Return the list of workflow templates
@@ -103,8 +101,6 @@ Return the list of workflow templates
 
 Return the list of steps for the given workflow template
 `GET   /workflow_templates/:workflow`
-
-`PUT    /:repo/objects/:druid/workflows/:workflow` - Deprecated. Use version without repo parameter instead.
 
 These processes are used by robot-master to discover which steps need to be performed.
 ```

--- a/spec/requests/workflows/single_workflow_for_object_spec.rb
+++ b/spec/requests/workflows/single_workflow_for_object_spec.rb
@@ -3,77 +3,38 @@
 require 'rails_helper'
 
 RSpec.describe 'Get a single workflow for an object', type: :request do
-  context 'when repo is supplied (deprecated)' do
-    context 'when a workflow exists for the object' do
-      let(:item) do
-        FactoryBot.create(:workflow_step,
-                          status: 'waiting',
-                          created_at: date)
-      end
-
-      let(:date) { Time.now.utc.iso8601.sub(/Z/, '+00:00') }
-      let(:druid) { item.druid }
-
-      it 'shows the workflow' do
-        get "/objects/#{druid}/workflows/accessionWF"
-        expect(response).to be_successful
-        expect(response.body).to be_equivalent_to <<~XML
-          <workflow objectId="#{druid}" id="accessionWF">
-            <process version="1" note="" lifecycle="" laneId="default"
-              elapsed="" attempts="0" datetime="#{date}"
-              status="waiting" name="start-accession"/>
-          </workflow>
-        XML
-      end
+  context 'when a workflow exists for the object' do
+    let(:item) do
+      FactoryBot.create(:workflow_step,
+                        status: 'waiting',
+                        created_at: date)
     end
 
-    context 'when no workflow exists' do
-      let(:druid) { 'druid:abc1232' }
+    let(:date) { Time.now.utc.iso8601.sub(/Z/, '+00:00') }
+    let(:druid) { item.druid }
 
-      it 'returns an empy workflow node' do
-        get "/objects/#{druid}/workflows/accessionWF"
-        expect(response).to be_successful
-        expect(response.body).to be_equivalent_to <<~XML
-          <workflow objectId="#{druid}" id="accessionWF" />
-        XML
-      end
+    it 'shows the workflow' do
+      get "/objects/#{druid}/workflows/accessionWF"
+      expect(response).to be_successful
+      expect(response.body).to be_equivalent_to <<~XML
+        <workflow objectId="#{druid}" id="accessionWF">
+          <process version="1" note="" lifecycle="" laneId="default"
+            elapsed="" attempts="0" datetime="#{date}"
+            status="waiting" name="start-accession"/>
+        </workflow>
+      XML
     end
   end
 
-  context 'when repo is not supplied' do
-    context 'when a workflow exists for the object' do
-      let(:item) do
-        FactoryBot.create(:workflow_step,
-                          status: 'waiting',
-                          created_at: date)
-      end
+  context 'when no workflow exists' do
+    let(:druid) { 'druid:bb123bb12342' }
 
-      let(:date) { Time.now.utc.iso8601.sub(/Z/, '+00:00') }
-      let(:druid) { item.druid }
-
-      it 'shows the workflow' do
-        get "/objects/#{druid}/workflows/accessionWF"
-        expect(response).to be_successful
-        expect(response.body).to be_equivalent_to <<~XML
-          <workflow objectId="#{druid}" id="accessionWF">
-            <process version="1" note="" lifecycle="" laneId="default"
-              elapsed="" attempts="0" datetime="#{date}"
-              status="waiting" name="start-accession"/>
-          </workflow>
-        XML
-      end
-    end
-
-    context 'when no workflow exists' do
-      let(:druid) { 'druid:bb123bb12342' }
-
-      it 'returns an empy workflow node' do
-        get "/objects/#{druid}/workflows/accessionWF"
-        expect(response).to be_successful
-        expect(response.body).to be_equivalent_to <<~XML
-          <workflow objectId="#{druid}" id="accessionWF" />
-        XML
-      end
+    it 'returns an empy workflow node' do
+      get "/objects/#{druid}/workflows/accessionWF"
+      expect(response).to be_successful
+      expect(response.body).to be_equivalent_to <<~XML
+        <workflow objectId="#{druid}" id="accessionWF" />
+      XML
     end
   end
 end

--- a/spec/services/workflow_template_loader_spec.rb
+++ b/spec/services/workflow_template_loader_spec.rb
@@ -10,16 +10,8 @@ RSpec.describe WorkflowTemplateLoader do
   describe '#workflow_filepath' do
     let(:workflow_filepath) { loader.workflow_filepath }
 
-    context 'when workflow and repo provided' do
-      it 'finds filepath' do
-        expect(workflow_filepath).to eq("config/workflows/#{workflow_name}.xml")
-      end
-    end
-
-    context 'when only workflow provided' do
-      it 'finds filepath' do
-        expect(workflow_filepath).to eq("config/workflows/#{workflow_name}.xml")
-      end
+    it 'finds filepath' do
+      expect(workflow_filepath).to eq("config/workflows/#{workflow_name}.xml")
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔

since this code no longer takes the repo parameter, no need for it to be called out in specs or in README.

## How was this change tested? 🤨

⚡ ⚠ If this change affects consumers, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** that exercise this service and/or test in [stage|qa] environment, in addition to specs. ⚡


