### PR TITLE
Ensure the transaction completes before sending messages

### DIFF
--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -19,7 +19,7 @@ class StepsController < ApplicationController
 
     # We need this transaction to be committed before we kick off indexing/next steps
     # or they could find the data to be in an outdated state.
-    WorkflowStep.transaction do 
+    WorkflowStep.transaction do
       step.update(parser.to_h)
     end
 


### PR DESCRIPTION

## Why was this change made? 🤔

We've seen cases where the indexing appears to index the old workflow state.  This could occur if the indexer starts working before the change is committed. This forces the transaction to commit before sending the messages.

Ref https://github.com/sul-dlss/dor_indexing_app/issues/879

## How was this change tested? 🤨
test suite
