### PR TITLE
Raise an error when the request is invalid

### DIFF
--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -11,8 +11,6 @@ class StepsController < ApplicationController
 
     step = find_step_for_process
 
-    return render plain: '', status: :not_found if step.nil?
-
     return render plain: process_mismatch_error(parser), status: :bad_request if parser.process != params[:process]
 
     return render plain: status_mismatch_error(step), status: :conflict if params['current-status'] && step.status != params['current-status']
@@ -68,7 +66,7 @@ class StepsController < ApplicationController
       raise "Duplicate workflow step for #{params[:druid]} #{params[:workflow]} #{params[:process]}"
     end
 
-    query.first
+    query.first || raise("step not found")
   end
   # rubocop:enable Metrics/AbcSize
 

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -66,7 +66,7 @@ class StepsController < ApplicationController
       raise "Duplicate workflow step for #{params[:druid]} #{params[:workflow]} #{params[:process]}"
     end
 
-    query.first || raise("step not found")
+    query.first || raise('step not found')
   end
   # rubocop:enable Metrics/AbcSize
 

--- a/spec/requests/workflows/update_step_spec.rb
+++ b/spec/requests/workflows/update_step_spec.rb
@@ -53,16 +53,13 @@ RSpec.describe 'Update a workflow step for an object', type: :request do
     end
   end
 
-  context 'when no matching step exists (Hydrus does this)' do
+  context 'when no matching step exists' do
     let(:druid) { 'druid:zz696qh8598' }
     let(:wf) { WorkflowStep.where(druid: druid, workflow: 'hydrusAssemblyWF', process: 'submit') }
     let(:process_xml) { '<process name="submit" status="completed" elapsed="3" lifecycle="submitted" laneId="default" note="Yay"/>' }
 
-    it 'returns a 404' do
-      put "/objects/#{druid}/workflows/hydrusAssemblyWF/submit", params: process_xml
-
-      expect(response).to be_not_found
-      expect(SendUpdateMessage).not_to have_received(:publish)
+    it 'raises an error' do
+      expect { put "/objects/#{druid}/workflows/hydrusAssemblyWF/submit", params: process_xml }.to raise_error 'step not found'
     end
   end
 


### PR DESCRIPTION

## Why was this change made? 🤔

Previously we had to handle this gracefully because Hydrus depended on this behavior. Now that Hydrus has been decommissioned, we no longer need to. Now this kind of request will be logged to Honeybadger so we can diagnose the problem.


## How was this change tested? 🤨
CI