### PR TITLE
add a delay before sending re-index message for end-accession

### DIFF
--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -24,6 +24,12 @@ class StepsController < ApplicationController
     # Enqueue next steps
     next_steps = NextStepService.enqueue_next_steps(step: step)
 
+    # https://github.com/sul-dlss/argo/issues/3817
+    # Theory is that many commits to solr are not being executed in the correct order, resulting in
+    # older data being indexed last.  This is an attempt to force a delay when indexing the very
+    # last step of the accessionWF.
+    sleep 1 if step.workflow == 'accessionWF' && step.process == 'end-accession' && step.status == 'completed'
+
     SendUpdateMessage.publish(step: step)
     render json: { next_steps: next_steps }
   end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes [sul-dlss/argo/issue/5817](https://github.com/sul-dlss/argo/issues/3817)

See https://github.com/sul-dlss/argo/issues/3817#issuecomment-1205834676 to theory that this change is based on.

## How was this change tested? 🤨

Deployed to -stage and ran pre-assembly integration tests to ensure it didn't break anything.

