### PR TITLE
use pry, not pry-rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'jbuilder', '~> 2.5'
 gem 'lograge'
 gem 'okcomputer'
 gem 'pg'
-gem 'pry-rails' # useful for prod debugging
+gem 'pry' # make it possible to use pry for IRB (in prod debugging)
 gem 'puma', '~> 5.3' # app server
 gem 'redis', '~> 4.0' # redis 5.x has breaking changes with resque, see https://github.com/resque/resque/issues/1821
 gem 'resque', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,8 +217,6 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-rails (0.3.9)
-      pry (>= 0.10.4)
     puma (5.6.5)
       nio4r (~> 2.0)
     racc (1.6.0)
@@ -360,7 +358,7 @@ DEPENDENCIES
   lograge
   okcomputer
   pg
-  pry-rails
+  pry
   puma (~> 5.3)
   rails (~> 7.0.0)
   redis (~> 4.0)


### PR DESCRIPTION
## Why was this change made? 🤔

`pry-rails` is no longer maintained;  some of us still prefer `pry`, tho.

## How was this change tested? 🤨

⚡ ⚠ If this change affects consumers, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** that exercise this service and/or test in [stage|qa] environment, in addition to specs. ⚡


