### PR TITLE
Provide missing context option key,

### DIFF
--- a/app/services/workflow_monitor.rb
+++ b/app/services/workflow_monitor.rb
@@ -33,6 +33,6 @@ class WorkflowMonitor
     return if queued.count.zero?
 
     Honeybadger.notify("#{queued.count} workflow steps have been queued for more than 12 hours. Perhaps there is a " \
-                       'problem with the robots.', { druids: queued.pluck(:druid) })
+                       'problem with the robots.', context: { druids: queued.pluck(:druid) })
   end
 end

--- a/spec/services/workflow_monitor_spec.rb
+++ b/spec/services/workflow_monitor_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe WorkflowMonitor do
       expect(Honeybadger).to have_received(:notify).with(/#{stale_started_msg}/)
 
       stale_msg = '1 workflow steps have been queued for more than 12 hours. '
-      expect(Honeybadger).to have_received(:notify).with(/#{stale_msg}/, { druids: [stale.druid] })
+      expect(Honeybadger).to have_received(:notify).with(/#{stale_msg}/, context: { druids: [stale.druid] })
     end
   end
 end


### PR DESCRIPTION


## Why was this change made? 🤔
The required key was missing.
See https://docs.honeybadger.io/lib/ruby/getting-started/reporting-errors/

## How was this change tested? 🤨
Test suite
