### PR TITLE
restore the behavior of returning a 404 when trying to update a missing workflow step

### DIFF
--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -16,10 +16,15 @@ class StepsController < ApplicationController
 
   # Update a single WorkflowStep
   # If there are next steps, they are enqueued.
-  def update # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/MethodLength
+  def update
     parser = ProcessParser.new(process_from_request_body, use_default_lane_id: false)
 
     step = find_step_for_process
+
+    return render plain: '', status: :not_found if step.nil?
 
     return render plain: process_mismatch_error(parser), status: :bad_request if parser.process != params[:process]
 
@@ -43,6 +48,9 @@ class StepsController < ApplicationController
     SendUpdateMessage.publish(step: step)
     render json: { next_steps: next_steps }
   end
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/MethodLength
 
   private
 
@@ -70,7 +78,7 @@ class StepsController < ApplicationController
       raise "Duplicate workflow step for #{params[:druid]} #{params[:workflow]} #{params[:process]}"
     end
 
-    query.first || raise('step not found')
+    query.first
   end
   # rubocop:enable Metrics/AbcSize
 

--- a/spec/requests/workflows/update_step_spec.rb
+++ b/spec/requests/workflows/update_step_spec.rb
@@ -53,13 +53,16 @@ RSpec.describe 'Update a workflow step for an object' do
     end
   end
 
-  context 'when no matching step exists' do
+  context 'when no matching step exists (e.g. pres cat looks for 404 response to create missing workflow)' do
     let(:druid) { 'druid:zz696qh8598' }
     let(:wf) { WorkflowStep.where(druid: druid, workflow: 'hydrusAssemblyWF', process: 'submit') }
     let(:process_xml) { '<process name="submit" status="completed" elapsed="3" lifecycle="submitted" laneId="default" note="Yay"/>' }
 
-    it 'raises an error' do
-      expect { put "/objects/#{druid}/workflows/hydrusAssemblyWF/submit", params: process_xml }.to raise_error 'step not found'
+    it 'returns a 404' do
+      put "/objects/#{druid}/workflows/hydrusAssemblyWF/submit", params: process_xml
+
+      expect(response).to be_not_found
+      expect(SendUpdateMessage).not_to have_received(:publish)
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔

discussed after standup just now.  consensus was to change this back to the way things were before https://github.com/sul-dlss/workflow-server-rails/pull/588 because

* this seems correct semantically (a `PUT` to a missing resource should be a 404, not a 500).
* and practically, preservation_catalog depends on the 404 (`Dor::MissingWorkflowException` from dor-workflow-client) to create `preservationAuditWF` when it isn't already present (see e.g. https://github.com/sul-dlss/preservation_catalog/blob/2b4d75030b673fe6f2a1c65e87a54febf851ce59/app/services/audit_reporters/audit_workflow_reporter.rb#L72-L100).

links for context:
* pres cat HB alert about being unable to PUT against preservationAuditWF for the druid: https://app.honeybadger.io/projects/54415/faults/93228428
* pres robots HB alert for the 500 it gets back from pres cat: https://app.honeybadger.io/projects/55564/faults/93065492
* example HB alert for WFS 500 instead of 404: https://app.honeybadger.io/projects/58890/faults/93131970
* druid i was testing with this past friday: https://argo.stanford.edu/view/druid:cg595vp1970


## How was this change tested? 🤨

unit tests

⚡ ⚠ If this change affects consumers, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** that exercise this service and/or test in [stage|qa] environment, in addition to specs. ⚡


