### PR TITLE
Handle Sidekiq Pro in docker build.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ workflows:
           context: dlss
           name: publish-latest
           image: suldlss/workflow-server
+          extra_build_args: --build-arg BUNDLE_GEMS__CONTRIBSYS__COM
           requires:
             - lint
             - test

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ RUN apk --no-cache add \
   postgresql-client \
   tzdata
 
+ARG BUNDLE_GEMS__CONTRIBSYS__COM
+ENV BUNDLE_GEMS__CONTRIBSYS__COM $BUNDLE_GEMS__CONTRIBSYS__COM
+
 # Get bundler 2.1
 RUN gem install bundler
 

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,5 +1,8 @@
 FROM ruby:3.0.3-alpine
 
+ARG BUNDLE_GEMS__CONTRIBSYS__COM
+ENV BUNDLE_GEMS__CONTRIBSYS__COM $BUNDLE_GEMS__CONTRIBSYS__COM
+
 # The postgres-client could be eliminated in production
 RUN apk --no-cache add \
   git \


### PR DESCRIPTION
## Why was this change made? 🤔
For the docker file to build, the proper Sidekiq Pro keys are needed.


## How was this change tested? 🤨

⚡ ⚠ If this change affects consumers, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** that exercise this service and/or test in [stage|qa] environment, in addition to specs. ⚡


