### PR TITLE
Adjust workflow monitoring periodicity and trigger timestamps

### DIFF
--- a/app/services/workflow_monitor.rb
+++ b/app/services/workflow_monitor.rb
@@ -17,11 +17,11 @@ class WorkflowMonitor
 
   def monitor_started_steps
     steps = WorkflowStep.started
-                        .where(WorkflowStep.arel_table[:updated_at].lt(24.hours.ago))
+                        .where(WorkflowStep.arel_table[:updated_at].lt(48.hours.ago))
                         .limit(1000)
 
     steps.each do |step|
-      Honeybadger.notify("Workflow step has been running for more than 24 hours: <druid:\"#{step.druid}\" " \
+      Honeybadger.notify("Workflow step has been running for more than 48 hours: <druid:\"#{step.druid}\" " \
                          "version:\"#{step.version}\" workflow:\"#{step.workflow}\" process:\"#{step.process}\">. " \
                          'Perhaps there is a problem with it.')
     end
@@ -29,10 +29,10 @@ class WorkflowMonitor
 
   def monitor_queued_steps
     queued = WorkflowStep.queued
-                         .where(WorkflowStep.arel_table[:updated_at].lt(12.hours.ago))
+                         .where(WorkflowStep.arel_table[:updated_at].lt(24.hours.ago))
     return if queued.count.zero?
 
-    Honeybadger.notify("#{queued.count} workflow steps have been queued for more than 12 hours. Perhaps there is a " \
+    Honeybadger.notify("#{queued.count} workflow steps have been queued for more than 24 hours. Perhaps there is a " \
                        'problem with the robots.', context: { druids: queued.pluck(:druid) })
   end
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -27,7 +27,7 @@ job_type :no_warnings_runner,
 
 # NOTE: this job uses HB checkins.
 # If you change the schedule, edit the HB checkin at https://app.honeybadger.io/projects/58890/check_ins
-every 60.minutes do
+every 6.hours do
   # Currently running Monitor (notification only for stuck workflow steps) instead of Sweeper (notification and requeueing).
   # If monitoring alone isn't adequate (e.g., due to large numbers of Redis timeouts), we may want to re-enable the sweeper.
   # no_warnings_runner 'Sweeper.sweep'

--- a/spec/services/workflow_monitor_spec.rb
+++ b/spec/services/workflow_monitor_spec.rb
@@ -62,11 +62,11 @@ RSpec.describe WorkflowMonitor do
       described_class.monitor
       expect(Honeybadger).to have_received(:notify).exactly(2).times
 
-      stale_started_msg = "Workflow step has been running for more than 24 hours: <druid:\"#{stale_started.druid}\" " \
+      stale_started_msg = "Workflow step has been running for more than 48 hours: <druid:\"#{stale_started.druid}\" " \
                           "version:\"3\" workflow:\"#{stale_started.workflow}\" process:\"start-accession\">."
       expect(Honeybadger).to have_received(:notify).with(/#{stale_started_msg}/)
 
-      stale_msg = '1 workflow steps have been queued for more than 12 hours. '
+      stale_msg = '1 workflow steps have been queued for more than 24 hours. '
       expect(Honeybadger).to have_received(:notify).with(/#{stale_msg}/, context: { druids: [stale.druid] })
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

We discussed making this change in our team dev planning meeting and ran it by the product owner, Andrew, who says running the job every 6 hours and only flagging things 48-hours old is sufficient.


## How was this change tested? 🤨

CI + deployed to QA to verify crontab change
