### PR TITLE
Additional debugging info

### DIFF
--- a/app/services/send_rabbitmq_message.rb
+++ b/app/services/send_rabbitmq_message.rb
@@ -3,9 +3,9 @@
 # Send a message to a RabbitMQ exchange that an item has been updated.
 class SendRabbitmqMessage
   def self.publish(step:)
-    Rails.logger.info "Publishing Rabbitmq Message for #{step.druid}"
+    Rails.logger.info "Publishing Rabbitmq Message for #{step.druid}: #{step.process}.#{step.status}"
     new(step:).publish
-    Rails.logger.info "Published Rabbitmq Message for #{step.druid}"
+    Rails.logger.info "Published Rabbitmq Message for #{step.druid}: #{step.process}.#{step.status}"
   end
 
   def initialize(step:, channel: $rabbitmq_channel) # rubocop:disable Style/GlobalVars


### PR DESCRIPTION
## Why was this change made? 🤔

it is helpful to additional logging info when rabbitmq messages are sent for debugging purposes

trying to debug a mystery in H2 and this would have been useful


