### PR TITLE
Adds version to workflow step message.

### DIFF
--- a/app/services/send_rabbitmq_message.rb
+++ b/app/services/send_rabbitmq_message.rb
@@ -14,7 +14,7 @@ class SendRabbitmqMessage
   end
 
   def publish
-    message = { druid: step.druid, action: 'workflow updated' }
+    message = { druid: step.druid, version: step.version, action: 'workflow updated' }
     exchange = channel.topic('sdr.workflow')
     exchange.publish(message.to_json, routing_key: "#{step.process}.#{step.status}")
   end


### PR DESCRIPTION
refs https://github.com/sul-dlss/pre-assembly/issues/1201

## Why was this change made? 🤔
So that pre-assembly can use this message without having to query for version.


## How was this change tested? 🤨

⚡ ⚠ If this change affects consumers, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** that exercise this service and/or test in [stage|qa] environment, in addition to specs. ⚡


