### PR TITLE
Send full complement of step info with rabbit message.

### DIFF
--- a/app/services/send_rabbitmq_message.rb
+++ b/app/services/send_rabbitmq_message.rb
@@ -14,7 +14,8 @@ class SendRabbitmqMessage
   end
 
   def publish
-    message = { druid: step.druid, version: step.version, action: 'workflow updated' }
+    message = step.attributes_for_process.merge(action: 'workflow updated')
+    Rails.logger.debug message
     exchange = channel.topic('sdr.workflow')
     exchange.publish(message.to_json, routing_key: "#{step.process}.#{step.status}")
   end

--- a/spec/services/send_rabbitmq_message_spec.rb
+++ b/spec/services/send_rabbitmq_message_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SendRabbitmqMessage do
+  describe '.publish' do
+    let(:service) { described_class.new(step:, channel:) }
+    let(:step) { FactoryBot.create(:workflow_step, druid:) }
+
+    let(:druid) { 'druid:bb123bc1234' }
+    let(:channel) { instance_double(Bunny::Channel) }
+    let(:exchange) { instance_double(Bunny::Exchange) }
+
+    before do
+      allow(channel).to receive(:topic).and_return(exchange)
+      allow(exchange).to receive(:publish)
+    end
+
+    it 'sends message' do
+      service.publish
+      expect(exchange).to have_received(:publish).with(
+        {
+          version: 1,
+          note: nil,
+          lifecycle: nil,
+          laneId: 'default',
+          elapsed: nil,
+          attempts: 0,
+          datetime: step.updated_at.to_time.iso8601,
+          status: 'waiting',
+          name: 'start-accession',
+          action: 'workflow updated'
+        }.to_json,
+        routing_key: 'start-accession.waiting'
+      )
+      expect(channel).to have_received(:topic).with('sdr.workflow')
+    end
+  end
+end


### PR DESCRIPTION
refs https://github.com/sul-dlss/pre-assembly/issues/1201

## Why was this change made? 🤔
Pre-assembly needs more workflow step info, so might as well send everything.


## How was this change tested? 🤨

⚡ ⚠ If this change affects consumers, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** that exercise this service and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit
