### PR TITLE
Restore step to start gisDelivery workflow.

### DIFF
--- a/config/workflows/gisAssemblyWF.xml
+++ b/config/workflows/gisAssemblyWF.xml
@@ -67,4 +67,8 @@
     <prereq>load-geo-metadata</prereq>
     <label>Finalize assembly workflow to prepare for assembly/delivery/discovery</label>
   </process>
+  <process name="start-delivery-workflow">
+    <prereq>finish-gis-assembly-workflow</prereq>
+    <label>Initiate gisDelivery workflow for the object</label>
+  </process>
 </workflow-def>


### PR DESCRIPTION
## Why was this change made? 🤔
Resolves https://github.com/sul-dlss/gis-robot-suite/issues/668 to restore step to start gisDeliveryWF from gisAssemblyWF. Goes with https://github.com/sul-dlss/gis-robot-suite/pull/670


## How was this change tested? 🤨
Deployed to stage and tested with updated integration test. 

⚡ ⚠ If this change affects consumers, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** that exercise this service and/or test in [stage|qa] environment, in addition to specs. ⚡


