### PR TITLE
reset-geowebcache is never being run

### DIFF
--- a/config/workflows/gisDeliveryWF.xml
+++ b/config/workflows/gisDeliveryWF.xml
@@ -16,11 +16,11 @@
     <label>Load layers into GeoServer</label>
   </process>
   <process name="reset-geowebcache">
-    <prereq>reset-geowebcache</prereq>
+    <prereq>load-geoserver</prereq>
     <label>Reset GeoWebCache for the layer</label>
   </process>
   <process name="finish-gis-delivery-workflow">
-    <prereq>load-geoserver</prereq>
+    <prereq>reset-geowebcache</prereq>
     <label>Finalize delivery workflow for the object</label>
   </process>
 </workflow-def>


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes https://github.com/sul-dlss/gis-robot-suite/issues/401

This step is never being run, because it appears to be misconfigured in the workflow definition (nothing has it as a pre-req...and it is the pre-req of itself).  This step was added way back here (3.5 years ago) incorrectly: https://github.com/sul-dlss/workflow-server-rails/commit/5f495a3444f764532a0ebadf4388497eafa9fee1 so it looks like it has never been run.

Not sure if this is a problem or not.

I manually ran the logic for the robot on stage for this object druid:st417qr9346 and it completed successfully (though it's not clear to me how to verify it did what was intended).  https://argo-stage.stanford.edu/view/druid:st417qr9346  