### PR TITLE
Remove author-metadata from gisAssembly

### DIFF
--- a/config/workflows/gisAssemblyWF.xml
+++ b/config/workflows/gisAssemblyWF.xml
@@ -7,12 +7,8 @@
     <prereq>start-gis-assembly-workflow</prereq>
     <label>Ensure proper registration of druid, source ID, and label</label>
   </process>
-  <process name="author-metadata">
-    <prereq>register-druid</prereq>
-    <label>Author metadata using ArcCatalog</label>
-  </process>
   <process name="extract-thumbnail">
-    <prereq>author-metadata</prereq>
+    <prereq>register-druid</prereq>
     <label>Extract thumbnail preview from ArcCatalog metadata</label>
   </process>
   <process name="extract-iso19139">


### PR DESCRIPTION
## Why was this change made? 🤔
Partially addresses https://github.com/sul-dlss/gis-robot-suite/issues/665 to remove use of `geoMetadata.xml`. Goes with accompanying gis-robot-suite PR https://github.com/sul-dlss/gis-robot-suite/pull/686

## How was this change tested? 🤨
Integration test on stage.  There are no druids currently in the author-metadata WF step on any environment, so this should be deployable to prod. 
