### PR TITLE
Remove unneeded load-geo-metadata

### DIFF
--- a/config/workflows/gisAssemblyWF.xml
+++ b/config/workflows/gisAssemblyWF.xml
@@ -17,7 +17,7 @@
   </process>
   <process name="generate-geo-metadata">
     <prereq>extract-iso19139</prereq>
-    <label>Convert ISO 19139 metadata into geoMetadata RDF XML file</label>
+    <label>Convert ISO 19139 metadata into geoMetadata RDF XML</label>
   </process>
   <process name="generate-mods">
     <prereq>generate-geo-metadata</prereq>
@@ -55,12 +55,8 @@
     <prereq>finish-data</prereq>
     <label>Generate contentMetadata manifest</label>
   </process>
-  <process name="load-geo-metadata">
-    <prereq>generate-content-metadata</prereq>
-    <label>Accession geoMetadata RDF XML file into SDR</label>
-  </process>
   <process name="finish-gis-assembly-workflow">
-    <prereq>load-geo-metadata</prereq>
+    <prereq>generate-content-metadata</prereq>
     <label>Finalize assembly workflow to prepare for assembly/delivery/discovery</label>
   </process>
   <process name="start-delivery-workflow">


### PR DESCRIPTION
## Why was this change made? 🤔
Goes with https://github.com/sul-dlss/gis-robot-suite/pull/698/files which is still in draft and and needs testing.  Before deploy, no druids should be in the load-geo-metadata step. 

## How was this change tested? 🤨
To be tested with integration tests. 

