### PR TITLE
Start accessionWF after gisAssemblyWF

### DIFF
--- a/config/workflows/gisDeliveryWF.xml
+++ b/config/workflows/gisDeliveryWF.xml
@@ -23,4 +23,8 @@
     <prereq>reset-geowebcache</prereq>
     <label>Finalize delivery workflow for the object</label>
   </process>
+  <process name="start-accession-workflow">
+    <prereq>finish-gis-delivery-workflow</prereq>
+    <label>Initiate accession workflow for the object</label>
+  </process>
 </workflow-def>


### PR DESCRIPTION
## Why was this change made? 🤔
Goes with gis-robot-suite PR (https://github.com/sul-dlss/gis-robot-suite/pull/725) to kick off accessionWF from gisDeliveryWF. 


## How was this change tested? 🤨
With integration test on a branch

⚡ ⚠ If this change affects consumers, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** that exercise this service and/or test in [stage|qa] environment, in addition to specs. ⚡


