### PR TITLE
Rename generate-content-metadata step in workflow

### DIFF
--- a/config/workflows/gisAssemblyWF.xml
+++ b/config/workflows/gisAssemblyWF.xml
@@ -48,7 +48,7 @@
     <label>Generate cocina structural</label>
   </process>
   <process name="finish-gis-assembly-workflow">
-    <prereq>generate-content-metadata</prereq>
+    <prereq>generate-structural</prereq>
     <label>Finalize assembly workflow to prepare for assembly/delivery/discovery</label>
   </process>
   <process name="start-delivery-workflow">

--- a/config/workflows/gisAssemblyWF.xml
+++ b/config/workflows/gisAssemblyWF.xml
@@ -43,9 +43,9 @@
     <prereq>normalize-data</prereq>
     <label>Extract bounding box from data for MODS record</label>
   </process>
-  <process name="generate-content-metadata">
+  <process name="generate-structural">
     <prereq>extract-boundingbox</prereq>
-    <label>Generate contentMetadata manifest</label>
+    <label>Generate cocina structural</label>
   </process>
   <process name="finish-gis-assembly-workflow">
     <prereq>generate-content-metadata</prereq>


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #719 - rename generate-content-metadata to generate-structural

Must go with https://github.com/sul-dlss/gis-robot-suite/pull/787

HOLD for coordination with gis-robot-suite change

## How was this change tested? 🤨

CI


