### PR TITLE
rename gisAssemblyWF normalize-data to something more accurate

### DIFF
--- a/config/workflows/gisAssemblyWF.xml
+++ b/config/workflows/gisAssemblyWF.xml
@@ -39,12 +39,12 @@
     <prereq>assign-placenames</prereq>
     <label>Package the digital work</label>
   </process>
-  <process name="normalize-data">
+  <process name="copy-data">
     <prereq>package-data</prereq>
-    <label>Reproject the data into common SRS projection and/or file format</label>
+    <label>Move files from temp to content directory</label>
   </process>
   <process name="extract-boundingbox">
-    <prereq>normalize-data</prereq>
+    <prereq>copy-data</prereq>
     <label>Extract bounding box from data for cocina descriptive</label>
   </process>
   <process name="generate-structural">


### PR DESCRIPTION
## Why was this change made? 🤔

accurate names are nice

goes with https://github.com/sul-dlss/gis-robot-suite/pull/826

## How was this change tested? 🤨

- [x] deploy to stage and integration test
  - https://argo-stage.stanford.edu/view/jy657jv4704
  - https://argo-stage.stanford.edu/view/hs454hs4477

⚡ ⚠ If this change affects consumers, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** that exercise this service and/or test in [stage|qa] environment, in addition to specs. ⚡


