### PR TITLE
Remove package-data step

### DIFF
--- a/config/workflows/gisAssemblyWF.xml
+++ b/config/workflows/gisAssemblyWF.xml
@@ -35,12 +35,8 @@
     <prereq>generate-descriptive</prereq>
     <label>Insert linked data into MODS record from gazetteer</label>
   </process>
-  <process name="package-data">
-    <prereq>assign-placenames</prereq>
-    <label>Package the digital work</label>
-  </process>
   <process name="copy-data">
-    <prereq>package-data</prereq>
+    <prereq>assign-placenames</prereq>
     <label>Move files from temp to content directory</label>
   </process>
   <process name="extract-boundingbox">


### PR DESCRIPTION
## Why was this change made? 🤔

This step is being removed from the gis-robot-suite, see https://github.com/sul-dlss/gis-robot-suite/pull/832

## How was this change tested? 🤨

⚡ ⚠ If this change affects consumers, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** that exercise this service and/or test in [stage|qa] environment, in addition to specs. ⚡


