### PR TITLE
Add metadata-cleanup step to gisDeliveryWF

### DIFF
--- a/config/workflows/gisDeliveryWF.xml
+++ b/config/workflows/gisDeliveryWF.xml
@@ -27,8 +27,12 @@
     <prereq>finish-gis-delivery-workflow</prereq>
     <label>Automatically reload the geo server</label>
   </process>
-  <process name="start-accession-workflow">
+  <process name="metadata-cleanup">
     <prereq>reload-geoserver</prereq>
+    <label>Clean up staged object metadata</label>
+  </process>
+  <process name="start-accession-workflow">
+    <prereq>metadata-cleanup</prereq>
     <label>Initiate accession workflow for the object</label>
   </process>
 </workflow-def>


### PR DESCRIPTION
## Why was this change made? 🤔

Adds the metadata-cleanup step. HOLD until https://github.com/sul-dlss/gis-robot-suite/pull/852

## How was this change tested? 🤨

⚡ ⚠ If this change affects consumers, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** that exercise this service and/or test in [stage|qa] environment, in addition to specs. ⚡


