### PR TITLE
Removes reload-geoserver step

### DIFF
--- a/config/workflows/gisDeliveryWF.xml
+++ b/config/workflows/gisDeliveryWF.xml
@@ -23,12 +23,8 @@
     <prereq>reset-geowebcache</prereq>
     <label>Finalize delivery workflow for the object</label>
   </process>
-  <process name="reload-geoserver">
-    <prereq>finish-gis-delivery-workflow</prereq>
-    <label>Automatically reload the geo server</label>
-  </process>
   <process name="metadata-cleanup">
-    <prereq>reload-geoserver</prereq>
+    <prereq>finish-gis-delivery-workflow</prereq>
     <label>Clean up staged object metadata</label>
   </process>
   <process name="start-accession-workflow">


### PR DESCRIPTION
## Why was this change made? 🤔

See https://github.com/sul-dlss/gis-robot-suite/issues/864

There are currently no GIS items in an error state in production, so this is safe to go out without disturbing in progress GIS workflows.

## How was this change tested? 🤨

GIS related integration tests:

- gis_accessioning_spec.rb
- preassembly_gis_raster_accessioning_spec.rb
- preassembly_gis_vector_accessioning_spec.rb

⚡ ⚠ If this change affects consumers, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** that exercise this service and/or test in [stage|qa] environment, in addition to specs. ⚡


