### PR TITLE
Adds techmd as a prereq for reset workspace in accessionWF

### DIFF
--- a/config/workflows/accessionWF.xml
+++ b/config/workflows/accessionWF.xml
@@ -32,6 +32,7 @@
   </process>
   <process batch-limit="1" error-limit="5" name="reset-workspace">
     <label>Reset workspace by renaming the druid-tree to a versioned directory</label>
+    <prereq>technical-metadata</prereq>
     <prereq>sdr-ingest-received</prereq>
     <prereq>publish</prereq>
     <prereq>shelve</prereq>


### PR DESCRIPTION
## Why was this change made? 🤔
Prevents workspace from being cleared before techmd is completed.


## How was this change tested? 🤨

⚡ ⚠ If this change affects consumers, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** that exercise this service and/or test in [stage|qa] environment, in addition to specs. ⚡


