### PR TITLE
Remove status from start-accession step to spin up a robot

### DIFF
--- a/config/workflows/accessionWF.xml
+++ b/config/workflows/accessionWF.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <workflow-def id="accessionWF">
-  <process lifecycle="submitted" name="start-accession" status="completed">
+  <process lifecycle="submitted" name="start-accession">
     <label>Start Accessioning</label>
   </process>
   <process batch-limit="1000" error-limit="10" name="technical-metadata">

--- a/spec/services/workflow_creator_spec.rb
+++ b/spec/services/workflow_creator_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe WorkflowCreator do
         create_workflow_steps
       end.to change(WorkflowStep, :count).by(10)
       expect(WorkflowStep.last.druid).to eq druid
-      first_step = WorkflowStep.find_by(druid:, process: 'shelve')
+      first_step = WorkflowStep.find_by(druid:, process: 'start-accession')
       expect(QueueService).to have_received(:enqueue).with(first_step)
       expect(SendUpdateMessage).to have_received(:publish).with(step: WorkflowStep)
     end
@@ -47,7 +47,7 @@ RSpec.describe WorkflowCreator do
         expect do
           create_workflow_steps
         end.not_to change(WorkflowStep, :count)
-        first_step = WorkflowStep.find_by(druid:, process: 'shelve')
+        first_step = WorkflowStep.find_by(druid:, process: 'start-accession')
         expect(QueueService).to have_received(:enqueue).with(first_step)
         # The first time was for the test setup in the before hook.
         expect(SendUpdateMessage).to have_received(:publish).with(step: WorkflowStep).twice

--- a/spec/services/workflow_transformer_spec.rb
+++ b/spec/services/workflow_transformer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe WorkflowTransformer do
       expect(transformer.initial_workflow.to_s).to be_equivalent_to <<~XML
         <?xml version="1.0"?>
         <workflow id="accessionWF">
-          <process name="start-accession" status="completed" attempts="1" lifecycle="submitted"/>
+          <process name="start-accession" status="waiting" lifecycle="submitted"/>
           <process name="technical-metadata" status="waiting"/>
           <process name="shelve" status="waiting"/>
           <process name="publish" status="waiting" lifecycle="published"/>


### PR DESCRIPTION
Partnered with https://github.com/sul-dlss/common-accessioning/pull/1171

# Why was this change made?

Connects to #738


# How was this change tested?

CI
