### PR TITLE
Enable new rubocop rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -471,3 +471,9 @@ RSpec/RemoveConst: # new in 2.26
   Enabled: true
 RSpec/RepeatedSubjectCall: # new in 2.27
   Enabled: true
+Style/MapIntoArray: # new in 1.63
+  Enabled: true
+RSpec/EmptyOutput: # new in 2.29
+  Enabled: true
+RSpec/UndescriptiveLiteralsDescription: # new in 2.29
+  Enabled: true


### PR DESCRIPTION
## Why was this change made? 🤔
Keep up to date. Avoid warnings when running rubocop.


## How was this change tested? 🤨

⚡ ⚠ If this change affects consumers, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** that exercise this service and/or test in [stage|qa] environment, in addition to specs. ⚡


