### PR TITLE
Let fetch-files run

### DIFF
--- a/config/workflows/ocrWF.xml
+++ b/config/workflows/ocrWF.xml
@@ -3,9 +3,13 @@
   <process name="start-ocr">
     <label>Initiate OCR for the object</label>
   </process>
-  <process name="ocr-create">
+  <process name="fetch-files">
     <prereq>start-ocr</prereq>
-    <label>Generate OCR for the content in the object (if requested and possible)</label>
+    <label>Copy files for OCR from Preservation</label>
+  </process>
+  <process name="ocr-create">
+    <prereq>fetch-files</prereq>
+    <label>Generate OCR for files</label>
   </process>
   <process name="split-ocr-xml">
     <prereq>ocr-create</prereq>


### PR DESCRIPTION
## Why was this change made? 🤔

After the ocrWF starts it should go get files in need of accessioning
from Preservation. If this step fails for whatever reason it can be
safely rerun since the start of the Abbyy job is done seprately, in the
next step start-ocr, or some subsequent yet-to-be-named step.

Closes #767

## How was this change tested? 🤨

Unit tests (soon an integration test hopefully!)

