### PR TITLE
add okcomputer check for ocr queue depth

### DIFF
--- a/app/services/next_step_service.rb
+++ b/app/services/next_step_service.rb
@@ -41,7 +41,7 @@ class NextStepService
       results_before_update
     end
 
-    # We mustn't enqueue steps before the transaction completes, otherwise the workers
+    # We must not enqueue steps before the transaction completes, otherwise the workers
     # could start working on it and find it to still be "waiting".
     results.each { |next_step| QueueService.enqueue(next_step) }
   end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes https://github.com/sul-dlss/common-accessioning/issues/1242
(alternative to https://github.com/sul-dlss/argo/pull/4454)

This monitors the size of the ocrWF:ocr-create queue (by looking at the number of objects waiting). If this gets too big, it likely means ABBYY has stopped processing. The check is fast (hits database) and simple (has no dependency other than what the app database).

Downsides: it doesn't tell you why the queue is big -- this could also mean the robots are not picking up items, the folder listener is down etc., but we have monitoring in place for other possibilities, so this adds an extra check for something outside our control (ABBYY itself).

## How was this change tested? 🤨

Localhost