### PR TITLE
Remove steps from versioningWF.

### DIFF
--- a/config/workflows/versioningWF.xml
+++ b/config/workflows/versioningWF.xml
@@ -3,12 +3,4 @@
   <process lifecycle="opened" name="start-version" status="completed">
     <label>Initiate new version of the object</label>
   </process>
-  <process name="submit-version" skip-queue="true">
-    <prereq>start-version</prereq>
-    <label>Assembly complete, submit for review or accessioning</label>
-  </process>
-  <process name="start-accession">
-    <prereq>review-version</prereq>
-    <label>Start accessioning</label>
-  </process>
 </workflow-def>

--- a/spec/requests/queues/objects_for_step_spec.rb
+++ b/spec/requests/queues/objects_for_step_spec.rb
@@ -253,16 +253,16 @@ RSpec.describe 'Objects for workstep' do
 
     let!(:waiting) do
       FactoryBot.create(:workflow_step,
-                        workflow: 'versioningWF',
-                        process: 'start-accession',
+                        workflow: 'preservationIngestWF',
+                        process: 'complete-ingest',
                         status: 'waiting',
                         active_version: true)
     end
 
     let!(:second_waiting) do
       FactoryBot.create(:workflow_step,
-                        workflow: 'versioningWF',
-                        process: 'start-accession',
+                        workflow: 'preservationIngestWF',
+                        process: 'complete-ingest',
                         status: 'waiting',
                         active_version: true)
     end
@@ -270,15 +270,15 @@ RSpec.describe 'Objects for workstep' do
     before do
       # It shouldn't show this one because it's the wrong process
       FactoryBot.create(:workflow_step,
-                        workflow: 'versioningWF',
-                        process: 'submit-version',
+                        workflow: 'preservationIngestWF',
+                        process: 'transfer-object',
                         status: 'waiting',
                         active_version: true)
     end
 
     context 'with repository-qualified step names' do
       it 'shows the items that are waiting' do
-        get '/workflow_queue?waiting=dor%3AversioningWF%3Astart-accession'
+        get '/workflow_queue?waiting=dor%3ApreservationIngestWF%3Acomplete-ingest'
 
         expect(response.body).to be_equivalent_to expected_xml
       end
@@ -286,7 +286,7 @@ RSpec.describe 'Objects for workstep' do
 
     context 'without repository-qualified step names' do
       it 'shows the items that are waiting' do
-        get '/workflow_queue?waiting=versioningWF%3Astart-accession'
+        get '/workflow_queue?waiting=preservationIngestWF%3Acomplete-ingest'
 
         expect(response.body).to be_equivalent_to expected_xml
       end


### PR DESCRIPTION
closes #775

## Why was this change made? 🤔
These steps are no longer used to control versioning.


## How was this change tested? 🤨

⚡ ⚠ If this change affects consumers, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** that exercise this service and/or test in [stage|qa] environment, in addition to specs. ⚡

stage integration
