### PR TITLE
Update ruby orb version to 4.2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ruby-rails: sul-dlss/ruby-rails@4.2.0
+  ruby-rails: sul-dlss/ruby-rails@4.2.1
 workflows:
   build:
     jobs:


### PR DESCRIPTION
## Why was this change made? 🤔

Latest version of ruby orb is 4.2.1

## How was this change tested? 🤨

⚡ ⚠ If this change affects consumers, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** that exercise this service and/or test in [stage|qa] environment, in addition to specs. ⚡


