### PR TITLE
Reorder ocrWF

### DIFF
--- a/config/workflows/ocrWF.xml
+++ b/config/workflows/ocrWF.xml
@@ -19,16 +19,16 @@
     <prereq>ocr-create</prereq>
     <label>Split full document OCR XML into page level OCR XML</label>
   </process>
-  <process name="update-cocina">
-    <prereq>split-ocr-xml</prereq>
-    <label>Add new OCR files to cocina structural with correct attributes</label>
-  </process>
   <process name="stage-files">
-    <prereq>update-cocina</prereq>
+    <prereq>split-ocr-xml</prereq>
     <label>Move new OCR files to workspace</label>
   </process>
-  <process name="end-ocr">
+  <process name="update-cocina">
     <prereq>stage-files</prereq>
+    <label>Add new OCR files to cocina structural with correct attributes</label>
+  </process>
+  <process name="end-ocr">
+    <prereq>update-cocina</prereq>
     <label>Complete OCR tasks for the object</label>
   </process>
 </workflow-def>


### PR DESCRIPTION
## Why was this change made? 🤔

The staging of files needs to happen prior to the update of Cocina,
since the CocinaUpdater looks in the workspace for files to use.

See https://github.com/sul-dlss/common-accessioning/issues/1185

## How was this change tested? 🤨

⚡ ⚠ If this change affects consumers, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** that exercise this service and/or test in [stage|qa] environment, in addition to specs. ⚡


