### PR TITLE
Configure separate queues for DSA robots.

### DIFF
--- a/app/models/workflow_step.rb
+++ b/app/models/workflow_step.rb
@@ -6,7 +6,7 @@ class WorkflowStep < ApplicationRecord
   validates :workflow, presence: true
   validates :process, presence: true
   validates :version, numericality: { only_integer: true }
-  validates :status, inclusion: { in: %w[waiting started completed queued error skipped] }
+  validates :status, inclusion: { in: %w[waiting started completed queued error skipped retrying] }
   validates :process, uniqueness: { scope: %w[version workflow druid] }
   validate  :workflow_exists, on: :create
   validate  :process_exists_for_workflow, on: :create

--- a/app/services/queue_service.rb
+++ b/app/services/queue_service.rb
@@ -26,6 +26,8 @@ class QueueService
 
   private
 
+  DSA_ROBOTS = ['Robots::DorRepo::Accession::Publish'].freeze
+
   # Generate the queue name from step
   #
   # @example
@@ -36,6 +38,9 @@ class QueueService
                       # Special case because this robot can eats up too much memory if more
                       # than one instance is running on a worker box simultaneously
                       'assemblyWF_jp2'
+                    elsif DSA_ROBOTS.include?(class_name)
+                      # DSA only handles certain robots. Those need to be sent to separate queues.
+                      "#{step.workflow}_#{step.lane_id}_dsa"
                     else
                       "#{step.workflow}_#{step.lane_id}"
                     end

--- a/compose.yaml
+++ b/compose.yaml
@@ -23,7 +23,7 @@ services:
     depends_on:
       - db
   db:
-    image: postgres
+    image: postgres:12
     ports:
       - "5432:5432"
     environment:

--- a/spec/services/queue_service_spec.rb
+++ b/spec/services/queue_service_spec.rb
@@ -22,6 +22,16 @@ RSpec.describe QueueService do
       end
     end
 
+    context 'when DSA robot (special case)' do
+      let(:step) { FactoryBot.create(:workflow_step, workflow: 'accessionWF', process: 'publish') }
+
+      it 'enqueues to Sidekiq' do
+        service.enqueue
+        expect(Sidekiq::Client).to have_received(:push).with('queue' => 'accessionWF_default_dsa',
+                                                             'class' => 'Robots::DorRepo::Accession::Publish', 'args' => [step.druid])
+      end
+    end
+
     context 'when DorRepo classes' do
       let(:step) { FactoryBot.create(:workflow_step, workflow: 'accessionWF', process: 'technical-metadata') }
 


### PR DESCRIPTION
## Why was this change made? 🤔
So that specific robots can be run within DSA.


## How was this change tested? 🤨
Unit, integration test

⚡ ⚠ If this change affects consumers, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** that exercise this service and/or test in [stage|qa] environment, in addition to specs. ⚡


