### PR TITLE
make specs more complete

### DIFF
--- a/spec/requests/workflows/create_workflow_spec.rb
+++ b/spec/requests/workflows/create_workflow_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'Create a workflow' do
     end
 
     context 'when the version is passed with context' do
-      let(:context) { { 'requireOCR' => true, 'requireTranscript' => true } }
+      let(:context) { { 'requireOCR' => true, 'requireTranscript' => true, 'ocrLanguages' => ['Russian'] } }
       let(:version) { 1 }
 
       it 'creates new workflows with context' do
@@ -76,8 +76,8 @@ RSpec.describe 'Create a workflow' do
     end
 
     context 'when the version is passed with updated context' do
-      let(:original_context) { { 'requireOCR' => true, 'requireTranscript' => true } }
-      let(:new_context) { { 'requireOCR' => false, 'requireTranscript' => true } }
+      let(:original_context) { { 'requireOCR' => true, 'requireTranscript' => 'true', 'ocrLanguages' => ['Russian'] } }
+      let(:new_context) { { 'requireOCR' => false, 'requireTranscript' => 'true', 'ocrLanguages' => ['Russian'] } }
       let(:version) { 1 }
 
       it 'updates existing workflow context' do


### PR DESCRIPTION
## Why was this change made? 🤔

Same as https://github.com/sul-dlss/dor-services-client/pull/557 for workflow-server-rails

Just verifying that languages come through as an array (for OCR work in the workflow context). Make the workflow context match what we actually expect to come through.  Ensure both boolean and non-boolean values and an array all work

Part of the investigation of https://github.com/sul-dlss/common-accessioning/issues/1495

