### PR TITLE
remove deprecated platforms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ source 'https://gems.contribsys.com/' do
 end
 
 group :development, :test do
-  gem 'byebug', platforms: %i[mri mingw x64_mingw]
+  gem 'byebug'
   gem 'equivalent-xml'
   # NOTE: factory_bot_rails >= 6.3.0 requires env/test.rb to have config.factory_bot.reject_primary_key_attributes = false
   gem 'factory_bot_rails'


### PR DESCRIPTION
## Why was this change made? 🤔

`[DEPRECATED] Platform :mingw, :x64_mingw is deprecated. Please use platform :windows instead.`


## How was this change tested? 🤨

⚡ ⚠ If this change affects consumers, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** that exercise this service and/or test in [stage|qa] environment, in addition to specs. ⚡


